### PR TITLE
Refactor: Implement Repository/UoW Patterns (Closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This project is managed using `uv` for dependency management and `ruff` for lint
 
 ## Core Features
 
-*   **Database:** Uses DuckDB via SQLModel ORM and the Repository pattern (`FileRepository`).
-*   **Schema:** Stores file metadata and content in the `filerecord` table, including `source_path`, `filename`, `blob`, `size_bytes`, `last_modified_ts`, `extracted_text` (Markdown), `status` (tracking processing stage), and `meta_data` (JSON).
+*   **Database:** Uses DuckDB via SQLModel ORM. Data access is managed using the **Repository pattern** (specifically `DocumentRepository` inheriting from `AbstractDocumentRepository`) and the **Unit of Work pattern** (`SqlModelUnitOfWork`) to ensure decoupled, testable, and transactional database interactions.
+*   **Schema:** Stores file metadata and content in the `filerecord` table, including `source_path`, `filename`, `blob`, `size_bytes`, `last_modified_ts`, `extracted_text` (Markdown), `status` (tracking processing stage), and `meta_data` (JSON). The repository provides methods for querying based on standard fields and generic JSON `meta_data` fields.
 *   **Ingestion Pipeline:** Provides a CLI (`reg-agent ingest run`) to execute a multi-stage ingestion pipeline:
     1.  **Record Creation:** Scans directories, reads file metadata, and creates initial `FileRecord` entries, skipping duplicates based on `source_path`.
     2.  **OCR Extraction:** Integrates with the `docling` library (`OcrService`) to automatically extract Markdown text from PDF files and store it in `extracted_text`.

--- a/src/reg_agent/core/db/__init__.py
+++ b/src/reg_agent/core/db/__init__.py
@@ -1,0 +1,4 @@
+from .repositories import AbstractDocumentRepository, DocumentRepository  # noqa: F401
+from .unit_of_work import AbstractUnitOfWork, SqlModelUnitOfWork  # noqa: F401
+from .models import FileRecord, FileStatus  # noqa: F401
+from .connection import get_session, create_db_and_tables, get_engine  # noqa: F401

--- a/src/reg_agent/core/db/models.py
+++ b/src/reg_agent/core/db/models.py
@@ -3,9 +3,9 @@ Defines the SQLModel ORM models for the database.
 """
 
 import uuid
-from datetime import datetime  # Import datetime object directly
+from datetime import datetime, timezone  # Add timezone
 from enum import Enum  # Import Enum
-from typing import Any, Dict, Optional  # Import Dict
+from typing import Any, Dict, Optional  # Add List for potential future use
 
 from sqlalchemy import Column, LargeBinary  # Import TIMESTAMP, Column, LargeBinary
 from sqlalchemy.types import JSON  # Import JSON
@@ -56,10 +56,11 @@ class FileRecord(SQLModel, table=True):
     last_modified_ts: Optional[datetime] = Field(default=None)
     # Processing status
     status: FileStatus = Field(default=FileStatus.PENDING_PROCESS, index=True)
-    # Timestamps for tracking
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    # Timestamps for tracking - use timezone.utc
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: Optional[datetime] = Field(
-        default_factory=datetime.utcnow, sa_column_kwargs={"onupdate": datetime.utcnow}
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column_kwargs={"onupdate": lambda: datetime.now(timezone.utc)},
     )
 
     # Future potential fields (examples):

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -2,9 +2,12 @@
 Contains repository classes for database interactions.
 """
 
-from typing import List  # Add List for type hinting
+import abc
+import uuid
+from typing import Any, Dict, List, Optional  # Combine typing imports
 
 import structlog
+from sqlalchemy import text # Add text import for later use
 from sqlmodel import Session, select
 
 from reg_agent.core.db.models import FileRecord, FileStatus
@@ -12,7 +15,67 @@ from reg_agent.core.db.models import FileRecord, FileStatus
 log = structlog.get_logger()
 
 
-class FileRepository:
+# --- Abstract Base Class for Repository ---
+class AbstractDocumentRepository(abc.ABC):
+    """Abstract interface for a document repository."""
+
+    @abc.abstractmethod
+    def add(self, record: FileRecord) -> None:
+        """Adds a new FileRecord to the repository."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_by_id(self, record_id: uuid.UUID) -> Optional[FileRecord]:
+        """Retrieves a FileRecord by its UUID."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def exists_by_source_path(self, source_path: str) -> bool:
+        """Checks if a record exists based on its source path."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def find_by_metadata(self, filters: Dict[str, Any]) -> List[FileRecord]:
+        """
+        Finds records by matching key-value pairs in the meta_data JSON field.
+
+        Args:
+            filters: A dictionary where keys are metadata field names
+                     and values are the values to filter by.
+        Returns:
+            A list of matching FileRecord objects.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_distinct_values(self, metadata_key: str) -> List[Any]:
+        """
+        Gets the distinct values for a specific key within the meta_data JSON field.
+
+        Args:
+            metadata_key: The key within the meta_data JSON to query.
+        Returns:
+            A list of unique values for the specified key.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_queryable_fields(self) -> List[str]:
+        """
+        Gets the list of metadata keys that are designated as queryable.
+        Returns:
+            A list of strings representing the queryable field names.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_records_by_status(self, status: FileStatus) -> List[FileRecord]:
+        """Retrieves all FileRecords with the specified status."""
+        raise NotImplementedError
+
+
+# --- Concrete Repository Implementation ---
+class DocumentRepository(AbstractDocumentRepository):
     """Handles database operations for FileRecord objects."""
 
     def __init__(self, session: Session):
@@ -23,7 +86,7 @@ class FileRepository:
             session: The SQLModel session to use for database operations.
         """
         self.session = session
-        log.debug("FileRepository initialized with session.")
+        log.debug("DocumentRepository initialized with session.")
 
     def add(self, record: FileRecord) -> None:
         """
@@ -51,6 +114,21 @@ class FileRepository:
             # to handle rollbacks appropriately.
             raise
 
+    def get_by_id(self, record_id: uuid.UUID) -> Optional[FileRecord]:
+        """Retrieves a FileRecord by its UUID."""
+        log.debug("Fetching record by ID", record_id=record_id)
+        try:
+            # SQLModel's session.get is efficient for primary key lookups
+            record = self.session.get(FileRecord, record_id)
+            if record:
+                log.debug("Record found by ID", record_id=record_id)
+            else:
+                log.debug("Record not found by ID", record_id=record_id)
+            return record
+        except Exception as e:
+            log.exception("Error fetching record by ID", record_id=record_id, error=str(e))
+            raise
+
     def exists_by_source_path(self, source_path: str) -> bool:
         """
         Checks if a record with the given source_path already exists.
@@ -63,9 +141,8 @@ class FileRepository:
         """
         log.debug("Checking existence by source_path", path=source_path)
         try:
-            statement = select(FileRecord).where(FileRecord.source_path == source_path)
             # Use select(1) or select(FileRecord.id) for efficiency if only existence is needed
-            # statement = select(1).where(FileRecord.source_path == source_path).limit(1)
+            statement = select(FileRecord.id).where(FileRecord.source_path == source_path).limit(1)
             result = self.session.exec(statement).first()
             exists = result is not None
             log.debug("Existence check result", path=source_path, exists=exists)
@@ -79,6 +156,66 @@ class FileRepository:
             # Depending on desired behavior, you might return False or re-raise
             # Re-raising is generally safer as it indicates an unexpected error.
             raise
+
+    def find_by_metadata(self, filters: Dict[str, Any]) -> List[FileRecord]:
+        """
+        Finds records by matching key-value pairs in the meta_data JSON field.
+
+        Args:
+            filters: A dictionary where keys are metadata field names
+                     and values are the values to filter by.
+                     Currently assumes string comparison for values.
+        Returns:
+            A list of matching FileRecord objects.
+        """
+        log.debug("Finding records by metadata filters", filters=filters)
+        try:
+            statement = select(FileRecord)
+            # Dynamically build WHERE clauses for each filter
+            for key, value in filters.items():
+                # Use DuckDB's json_extract_string via text()
+                # Ensure key is prefixed with '$' for JSON path
+                # Bind parameters to prevent SQL injection
+                # Note: This assumes the value in the JSON is stored as a string
+                #       or can be compared as a string.
+                condition = text("json_extract_string(meta_data, :key) = :value")
+                statement = statement.where(condition).params(key=f'$.{key}', value=str(value))
+
+            results = self.session.exec(statement).all()
+            log.info("Found records by metadata", count=len(results), filters=filters)
+            return list(results)
+        except Exception as e:
+            log.exception(
+                "Error finding records by metadata", filters=filters, error=str(e)
+            )
+            raise
+
+    def get_distinct_values(self, metadata_key: str) -> List[Any]:
+        """
+        Gets the distinct values for a specific key within the meta_data JSON field.
+        (Placeholder implementation - requires specific JSON query logic)
+        """
+        log.warning(
+            "get_distinct_values needs implementation",
+            metadata_key=metadata_key,
+        )
+        # TODO: Implement actual distinct value query on JSON field for DuckDB
+        # Example using raw SQL might be needed if SQLModel/SQLAlchemy Core is tricky:
+        # query = f"""SELECT DISTINCT json_extract_string(meta_data, '$')
+        #           FROM filerecord
+        #           WHERE json_extract_string(meta_data, '$') IS NOT NULL"""
+        # result = self.session.exec(text(query))
+        # return result.scalars().all()
+        raise NotImplementedError # Use raise until implemented
+
+    def get_queryable_fields(self) -> List[str]:
+        """
+        Gets the list of metadata keys that are designated as queryable.
+        (Placeholder implementation - returns hardcoded list)
+        """
+        log.debug("Returning predefined list of queryable metadata fields")
+        # TODO: Make this dynamic (e.g., from config or introspection) if needed
+        return ["author", "title", "year", "topic", "case_number"] # Example fields
 
     def get_records_by_status(self, status: FileStatus) -> List[FileRecord]:
         """Retrieves all FileRecords with the specified status."""
@@ -123,8 +260,6 @@ class FileRepository:
             raise
 
     # Add other necessary methods here later, e.g.:
-    # def get_by_id(self, record_id: uuid.UUID) -> Optional[FileRecord]:
-    #     ...
     # def get_by_source_path(self, source_path: str) -> Optional[FileRecord]:
     #     ...
     # def list_all(self) -> List[FileRecord]:

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -2,78 +2,17 @@
 Contains repository classes for database interactions.
 """
 
-import abc
 import uuid
-from typing import Any, Dict, List, Optional  # Added Generator
+from typing import Any, Dict, List, Optional
 
 import structlog
-from sqlalchemy import text, and_  # Added and_
+from sqlalchemy import text, and_
 from sqlmodel import Session, select
 
 from reg_agent.core.db.models import FileRecord, FileStatus
+from reg_agent.core.db.repository_abc import AbstractDocumentRepository
 
 log = structlog.get_logger()
-
-
-# --- Abstract Base Class for Repository ---
-class AbstractDocumentRepository(abc.ABC):
-    """Abstract interface for a document repository."""
-
-    @abc.abstractmethod
-    def add(self, record: FileRecord) -> None:
-        """Adds a new FileRecord to the repository."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_by_id(self, record_id: uuid.UUID) -> Optional[FileRecord]:
-        """Retrieves a FileRecord by its UUID."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def exists_by_source_path(self, source_path: str) -> bool:
-        """Checks if a record exists based on its source path."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def find_by_metadata(self, filters: Dict[str, Any]) -> List[FileRecord]:
-        """
-        Finds records by matching key-value pairs in the meta_data JSON field.
-
-        Args:
-            filters: A dictionary where keys are metadata field names
-                     and values are the values to filter by.
-        Returns:
-            A list of matching FileRecord objects.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_distinct_values(self, metadata_key: str) -> List[Any]:
-        """
-        Gets the distinct, non-null string values for a specific key
-        within the meta_data JSON field across all records.
-
-        Args:
-            metadata_key: The key within the meta_data JSON to query.
-        Returns:
-            A sorted list of unique string values for the specified key.
-            Returns an empty list if the key doesn't exist or has no non-null values.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_queryable_fields(self) -> List[str]:
-        """
-        Gets the list of metadata keys that are designated as queryable.
-        Returns:
-            A list of strings representing the queryable field names.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_records_by_status(self, status: FileStatus) -> List[FileRecord]:
-        """Retrieves all FileRecords with the specified status."""
-        raise NotImplementedError
 
 
 # --- Concrete Repository Implementation ---
@@ -116,7 +55,7 @@ class DocumentRepository(AbstractDocumentRepository):
             # to handle rollbacks appropriately.
             raise
 
-    def get_by_id(self, record_id: uuid.UUID) -> Optional[FileRecord]:
+    def get(self, record_id: uuid.UUID) -> Optional[FileRecord]:
         """Retrieves a FileRecord by its UUID."""
         log.debug("Fetching record by ID", record_id=record_id)
         try:
@@ -131,6 +70,18 @@ class DocumentRepository(AbstractDocumentRepository):
             log.exception(
                 "Error fetching record by ID", record_id=record_id, error=str(e)
             )
+            raise
+
+    def list(self) -> List[FileRecord]:
+        """Retrieves all FileRecord entities from the repository."""
+        log.debug("Fetching all records")
+        try:
+            statement = select(FileRecord)
+            results = self.session.exec(statement).all()
+            log.info("Fetched all records", count=len(results))
+            return list(results)
+        except Exception as e:
+            log.exception("Error fetching all records", error=str(e))
             raise
 
     def exists_by_source_path(self, source_path: str) -> bool:
@@ -165,7 +116,9 @@ class DocumentRepository(AbstractDocumentRepository):
             # Re-raising is generally safer as it indicates an unexpected error.
             raise
 
-    def find_by_metadata(self, filters: Dict[str, Any]) -> List[FileRecord]:
+    def find_by_metadata(
+        self, filters: Dict[str, Any], limit: int | None = None
+    ) -> List[FileRecord]:
         """
         Finds records by matching key-value pairs in the meta_data JSON field.
 
@@ -173,10 +126,11 @@ class DocumentRepository(AbstractDocumentRepository):
             filters: A dictionary where keys are metadata field names
                      and values are the values to filter by.
                      Currently assumes string comparison for values.
+            limit: Optional maximum number of records to return.
         Returns:
             A list of matching FileRecord objects.
         """
-        log.debug("Finding records by metadata filters", filters=filters)
+        log.debug("Finding records by metadata filters", filters=filters, limit=limit)
         try:
             statement = select(FileRecord)
             conditions = []
@@ -200,9 +154,13 @@ class DocumentRepository(AbstractDocumentRepository):
                 # Apply all conditions using 'and_'
                 statement = statement.where(and_(*conditions))
 
+            # Apply limit if provided
+            if limit is not None:
+                statement = statement.limit(limit)
+
             # Execute with the combined parameters using session.execute
             results = self.session.execute(statement, params_dict).scalars().all()
-            log.info("Found records by metadata", count=len(results), filters=filters)
+            log.info("Found records by metadata", count=len(results), filters=filters, limit=limit)
             return list(results)
         except Exception as e:
             log.exception(

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -4,10 +4,10 @@ Contains repository classes for database interactions.
 
 import abc
 import uuid
-from typing import Any, Dict, List, Optional  # Combine typing imports
+from typing import Any, Dict, List, Optional, Generator  # Added Generator
 
 import structlog
-from sqlalchemy import text # Add text import for later use
+from sqlalchemy import text, and_  # Added and_
 from sqlmodel import Session, select
 
 from reg_agent.core.db.models import FileRecord, FileStatus
@@ -50,12 +50,14 @@ class AbstractDocumentRepository(abc.ABC):
     @abc.abstractmethod
     def get_distinct_values(self, metadata_key: str) -> List[Any]:
         """
-        Gets the distinct values for a specific key within the meta_data JSON field.
+        Gets the distinct, non-null string values for a specific key
+        within the meta_data JSON field across all records.
 
         Args:
             metadata_key: The key within the meta_data JSON to query.
         Returns:
-            A list of unique values for the specified key.
+            A sorted list of unique string values for the specified key.
+            Returns an empty list if the key doesn't exist or has no non-null values.
         """
         raise NotImplementedError
 
@@ -171,17 +173,29 @@ class DocumentRepository(AbstractDocumentRepository):
         log.debug("Finding records by metadata filters", filters=filters)
         try:
             statement = select(FileRecord)
+            conditions = []
+            params_dict = {}
+            i = 0
             # Dynamically build WHERE clauses for each filter
             for key, value in filters.items():
+                # Use unique param names for each condition
+                param_key_name = f"key_{i}"
+                param_value_name = f"value_{i}"
                 # Use DuckDB's json_extract_string via text()
-                # Ensure key is prefixed with '$' for JSON path
-                # Bind parameters to prevent SQL injection
-                # Note: This assumes the value in the JSON is stored as a string
-                #       or can be compared as a string.
-                condition = text("json_extract_string(meta_data, :key) = :value")
-                statement = statement.where(condition).params(key=f'$.{key}', value=str(value))
+                condition = text(
+                    f"json_extract_string(meta_data, :{param_key_name}) = :{param_value_name}"
+                )
+                conditions.append(condition)
+                params_dict[param_key_name] = f'$.{key}'
+                params_dict[param_value_name] = str(value)
+                i += 1
 
-            results = self.session.exec(statement).all()
+            if conditions:
+                # Apply all conditions using 'and_'
+                statement = statement.where(and_(*conditions))
+
+            # Execute with the combined parameters using session.execute
+            results = self.session.execute(statement, params_dict).scalars().all()
             log.info("Found records by metadata", count=len(results), filters=filters)
             return list(results)
         except Exception as e:
@@ -192,21 +206,43 @@ class DocumentRepository(AbstractDocumentRepository):
 
     def get_distinct_values(self, metadata_key: str) -> List[Any]:
         """
-        Gets the distinct values for a specific key within the meta_data JSON field.
-        (Placeholder implementation - requires specific JSON query logic)
+        Gets the distinct, non-null string values for a specific key
+        within the meta_data JSON field across all records.
+
+        Args:
+            metadata_key: The key within the meta_data JSON to query.
+        Returns:
+            A sorted list of unique string values for the specified key.
+            Returns an empty list if the key doesn't exist or has no non-null values.
         """
-        log.warning(
-            "get_distinct_values needs implementation",
-            metadata_key=metadata_key,
-        )
-        # TODO: Implement actual distinct value query on JSON field for DuckDB
-        # Example using raw SQL might be needed if SQLModel/SQLAlchemy Core is tricky:
-        # query = f"""SELECT DISTINCT json_extract_string(meta_data, '$')
-        #           FROM filerecord
-        #           WHERE json_extract_string(meta_data, '$') IS NOT NULL"""
-        # result = self.session.exec(text(query))
-        # return result.scalars().all()
-        raise NotImplementedError # Use raise until implemented
+        log.debug("Getting distinct values for metadata key", key=metadata_key)
+        try:
+            # Construct the JSON path expression
+            json_path = f'$.{metadata_key}'
+            # Use text() for DuckDB's json_extract_string and DISTINCT
+            # Filter out NULL results from json_extract_string
+            query = text(
+                "SELECT DISTINCT json_extract_string(meta_data, :key) as value "
+                "FROM filerecord "
+                "WHERE json_extract_string(meta_data, :key) IS NOT NULL "
+                "ORDER BY value"
+            )
+            # Use session.execute and pass params correctly
+            results = self.session.execute(query, {"key": json_path}).scalars().all()
+            log.info(
+                "Found distinct values for key",
+                key=metadata_key,
+                count=len(results),
+            )
+            # Ensure results are strings
+            return [str(r) for r in results]
+        except Exception as e:
+            log.exception(
+                "Error getting distinct values for metadata key",
+                key=metadata_key,
+                error=str(e),
+            )
+            raise
 
     def get_queryable_fields(self) -> List[str]:
         """

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -217,19 +217,25 @@ class DocumentRepository(AbstractDocumentRepository):
         # TODO: Make this dynamic (e.g., from config or introspection) if needed
         return ["author", "title", "year", "topic", "case_number"]  # Example fields
 
-    def get_records_by_status(self, status: FileStatus) -> List[FileRecord]:
-        """Retrieves all FileRecords with the specified status."""
-        log.debug("Fetching records by status", status=status.value)
-        try:
+    def get_records_by_status(self, status: FileStatus | List[FileStatus]) -> List[FileRecord]:
+        """Retrieves all FileRecords with the specified status or list of statuses."""
+        if isinstance(status, list):
+            status_values = [s.value for s in status]
+            log.debug("Fetching records by list of statuses", statuses=status_values)
+            statement = select(FileRecord).where(FileRecord.status.in_(status_values))
+        else:
+            log.debug("Fetching records by status", status=status.value)
             statement = select(FileRecord).where(FileRecord.status == status)
+
+        try:
             results = self.session.exec(statement).all()
             log.info(
-                "Fetched records by status", status=status.value, count=len(results)
+                "Fetched records by status(es)", status_query=str(status), count=len(results)
             )
             return list(results)  # Ensure it's a list
         except Exception as e:
             log.exception(
-                "Error fetching records by status", status=status.value, error=str(e)
+                "Error fetching records by status(es)", status_query=str(status), error=str(e)
             )
             raise
 

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -160,7 +160,12 @@ class DocumentRepository(AbstractDocumentRepository):
 
             # Execute with the combined parameters using session.execute
             results = self.session.execute(statement, params_dict).scalars().all()
-            log.info("Found records by metadata", count=len(results), filters=filters, limit=limit)
+            log.info(
+                "Found records by metadata",
+                count=len(results),
+                filters=filters,
+                limit=limit,
+            )
             return list(results)
         except Exception as e:
             log.exception(
@@ -217,7 +222,9 @@ class DocumentRepository(AbstractDocumentRepository):
         # TODO: Make this dynamic (e.g., from config or introspection) if needed
         return ["author", "title", "year", "topic", "case_number"]  # Example fields
 
-    def get_records_by_status(self, status: FileStatus | List[FileStatus]) -> List[FileRecord]:
+    def get_records_by_status(
+        self, status: FileStatus | List[FileStatus]
+    ) -> List[FileRecord]:
         """Retrieves all FileRecords with the specified status or list of statuses."""
         if isinstance(status, list):
             status_values = [s.value for s in status]
@@ -230,12 +237,16 @@ class DocumentRepository(AbstractDocumentRepository):
         try:
             results = self.session.exec(statement).all()
             log.info(
-                "Fetched records by status(es)", status_query=str(status), count=len(results)
+                "Fetched records by status(es)",
+                status_query=str(status),
+                count=len(results),
             )
             return list(results)  # Ensure it's a list
         except Exception as e:
             log.exception(
-                "Error fetching records by status(es)", status_query=str(status), error=str(e)
+                "Error fetching records by status(es)",
+                status_query=str(status),
+                error=str(e),
             )
             raise
 

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -4,7 +4,7 @@ Contains repository classes for database interactions.
 
 import abc
 import uuid
-from typing import Any, Dict, List, Optional, Generator  # Added Generator
+from typing import Any, Dict, List, Optional  # Added Generator
 
 import structlog
 from sqlalchemy import text, and_  # Added and_
@@ -128,7 +128,9 @@ class DocumentRepository(AbstractDocumentRepository):
                 log.debug("Record not found by ID", record_id=record_id)
             return record
         except Exception as e:
-            log.exception("Error fetching record by ID", record_id=record_id, error=str(e))
+            log.exception(
+                "Error fetching record by ID", record_id=record_id, error=str(e)
+            )
             raise
 
     def exists_by_source_path(self, source_path: str) -> bool:
@@ -144,7 +146,11 @@ class DocumentRepository(AbstractDocumentRepository):
         log.debug("Checking existence by source_path", path=source_path)
         try:
             # Use select(1) or select(FileRecord.id) for efficiency if only existence is needed
-            statement = select(FileRecord.id).where(FileRecord.source_path == source_path).limit(1)
+            statement = (
+                select(FileRecord.id)
+                .where(FileRecord.source_path == source_path)
+                .limit(1)
+            )
             result = self.session.exec(statement).first()
             exists = result is not None
             log.debug("Existence check result", path=source_path, exists=exists)
@@ -186,7 +192,7 @@ class DocumentRepository(AbstractDocumentRepository):
                     f"json_extract_string(meta_data, :{param_key_name}) = :{param_value_name}"
                 )
                 conditions.append(condition)
-                params_dict[param_key_name] = f'$.{key}'
+                params_dict[param_key_name] = f"$.{key}"
                 params_dict[param_value_name] = str(value)
                 i += 1
 
@@ -218,7 +224,7 @@ class DocumentRepository(AbstractDocumentRepository):
         log.debug("Getting distinct values for metadata key", key=metadata_key)
         try:
             # Construct the JSON path expression
-            json_path = f'$.{metadata_key}'
+            json_path = f"$.{metadata_key}"
             # Use text() for DuckDB's json_extract_string and DISTINCT
             # Filter out NULL results from json_extract_string
             query = text(
@@ -251,7 +257,7 @@ class DocumentRepository(AbstractDocumentRepository):
         """
         log.debug("Returning predefined list of queryable metadata fields")
         # TODO: Make this dynamic (e.g., from config or introspection) if needed
-        return ["author", "title", "year", "topic", "case_number"] # Example fields
+        return ["author", "title", "year", "topic", "case_number"]  # Example fields
 
     def get_records_by_status(self, status: FileStatus) -> List[FileRecord]:
         """Retrieves all FileRecords with the specified status."""

--- a/src/reg_agent/core/db/repositories.py
+++ b/src/reg_agent/core/db/repositories.py
@@ -125,7 +125,7 @@ class DocumentRepository(AbstractDocumentRepository):
         Args:
             filters: A dictionary where keys are metadata field names
                      and values are the values to filter by.
-                     Currently assumes string comparison for values.
+                     Supports string, numeric, and boolean filter values.
             limit: Optional maximum number of records to return.
         Returns:
             A list of matching FileRecord objects.
@@ -141,13 +141,31 @@ class DocumentRepository(AbstractDocumentRepository):
                 # Use unique param names for each condition
                 param_key_name = f"key_{i}"
                 param_value_name = f"value_{i}"
-                # Use DuckDB's json_extract_string via text()
+
+                # Determine the appropriate JSON extraction function based on the value type
+                if isinstance(value, str):
+                    extraction_function = "json_extract_string"
+                elif isinstance(value, (int, float, bool)):
+                    extraction_function = "json_extract"
+                else:
+                    # Optional: Handle other types or raise an error
+                    log.warning(
+                        "Unsupported filter value type, attempting string extraction.",
+                        key=key,
+                        type=type(value),
+                    )
+                    # Fallback to string extraction might be desired in some cases,
+                    # or raise ValueError(f"Unsupported filter value type: {type(value)}")
+                    extraction_function = "json_extract_string"
+                    value = str(value) # Coerce if falling back to string
+
+                # Use DuckDB's json_extract/json_extract_string via text()
                 condition = text(
-                    f"json_extract_string(meta_data, :{param_key_name}) = :{param_value_name}"
+                    f"{extraction_function}(meta_data, :{param_key_name}) = :{param_value_name}"
                 )
                 conditions.append(condition)
                 params_dict[param_key_name] = f"$.{key}"
-                params_dict[param_value_name] = str(value)
+                params_dict[param_value_name] = value  # Pass the original value
                 i += 1
 
             if conditions:
@@ -229,7 +247,7 @@ class DocumentRepository(AbstractDocumentRepository):
         if isinstance(status, list):
             status_values = [s.value for s in status]
             log.debug("Fetching records by list of statuses", statuses=status_values)
-            statement = select(FileRecord).where(FileRecord.status.in_(status_values))
+            statement = select(FileRecord).where(FileRecord.status.in_(status_values))  # Use ColumnOperators.in_
         else:
             log.debug("Fetching records by status", status=status.value)
             statement = select(FileRecord).where(FileRecord.status == status)

--- a/src/reg_agent/core/db/repository_abc.py
+++ b/src/reg_agent/core/db/repository_abc.py
@@ -85,4 +85,4 @@ class AbstractDocumentRepository(AbstractRepository[FileRecord, uuid.UUID]):
         Returns:
             A list of queryable metadata field names.
         """
-        raise NotImplementedError 
+        raise NotImplementedError

--- a/src/reg_agent/core/db/repository_abc.py
+++ b/src/reg_agent/core/db/repository_abc.py
@@ -1,0 +1,88 @@
+import uuid
+from abc import ABC, abstractmethod
+from typing import Any, Generic, List, Optional, TypeVar
+
+from sqlmodel import SQLModel
+
+from .models import FileRecord, FileStatus
+
+# Define TypeVars for generic repository
+T = TypeVar("T", bound=SQLModel)
+IdType = TypeVar("IdType")
+
+
+class AbstractRepository(ABC, Generic[T, IdType]):
+    """Abstract base class for a generic repository."""
+
+    @abstractmethod
+    def add(self, entity: T) -> None:
+        """Adds a new entity to the repository."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self, id: IdType) -> Optional[T]:
+        """Retrieves an entity by its identifier."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def list(self) -> List[T]:
+        """Retrieves all entities from the repository."""
+        raise NotImplementedError
+
+
+class AbstractDocumentRepository(AbstractRepository[FileRecord, uuid.UUID]):
+    """Abstract interface specific to the FileRecord repository."""
+
+    @abstractmethod
+    def get(self, id: uuid.UUID) -> Optional[FileRecord]:
+        """Retrieves a FileRecord entity by its identifier."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def exists_by_source_path(self, source_path: str) -> bool:
+        """Checks if a record exists based on its source path."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_records_by_status(self, status: FileStatus) -> List[FileRecord]:
+        """Retrieves records based on their processing status."""
+        raise NotImplementedError
+
+    # --- Methods for Issue #18 --- #
+
+    @abstractmethod
+    def find_by_metadata(
+        self, metadata_filter: dict[str, Any], limit: Optional[int] = None
+    ) -> List[FileRecord]:
+        """Finds records matching the provided metadata filter.
+
+        Args:
+            metadata_filter: A dictionary where keys are metadata fields
+                             and values are the expected values.
+            limit: Optional maximum number of records to return.
+
+        Returns:
+            A list of matching FileRecord objects.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_distinct_values(self, metadata_key: str) -> List[Any]:
+        """Gets distinct values for a specific key within the metadata JSON field.
+
+        Args:
+            metadata_key: The key within the JSON metadata to query.
+
+        Returns:
+            A list of unique values found for that key across all records.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_queryable_fields(self) -> List[str]:
+        """Gets the list of metadata fields considered safe/indexed for querying.
+
+        Returns:
+            A list of queryable metadata field names.
+        """
+        raise NotImplementedError 

--- a/src/reg_agent/core/db/unit_of_work.py
+++ b/src/reg_agent/core/db/unit_of_work.py
@@ -1,0 +1,147 @@
+# src/reg_agent/core/db/unit_of_work.py
+import abc
+from types import TracebackType
+from typing import Callable, Optional, Type
+
+import structlog
+from sqlmodel import Session
+
+# Assuming get_session context manager is in connection.py
+from reg_agent.core.db.connection import get_session
+from reg_agent.core.db.repositories import (
+    AbstractDocumentRepository,
+    DocumentRepository,
+)
+
+log = structlog.get_logger()
+
+
+class AbstractUnitOfWork(abc.ABC):
+    """Abstract base class for the Unit of Work pattern."""
+
+    documents: AbstractDocumentRepository
+
+    def __enter__(self) -> "AbstractUnitOfWork":
+        log.debug("Entering Unit of Work context.")
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        try:  # Wrap commit/rollback logic
+            if exc_type:
+                log.error(
+                    "Unit of Work exiting with exception from 'with' block, rolling back.",  # Clarified log
+                    exc_type=exc_type.__name__,
+                    exc_value=str(exc_value),
+                )
+                self.rollback()
+            else:
+                log.debug(
+                    "Unit of Work exiting normally, attempting commit."
+                )  # Clarified log
+                self.commit()  # Can still raise here
+        finally:  # Ensure close is always called
+            log.debug("Ensuring Unit of Work resources are closed.")
+            self.close()
+
+    @abc.abstractmethod
+    def commit(self) -> None:
+        """Commits the current transaction."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def rollback(self) -> None:
+        """Rolls back the current transaction."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Closes the session or releases resources."""
+        raise NotImplementedError
+
+
+class SqlModelUnitOfWork(AbstractUnitOfWork):
+    """Concrete Unit of Work implementation using SQLModel Session."""
+
+    def __init__(self, session_factory: Callable[[], Session] = Session):
+        """
+        Initializes the Unit of Work.
+
+        Args:
+            session_factory: A callable that returns a new SQLModel Session.
+                             Defaults to SQLModel's Session constructor, assuming
+                             an engine is globally configured or passed later.
+                             In practice, use a configured session maker.
+        """
+        # This session factory setup might need refinement based on how
+        # get_session or engine is managed globally/passed around.
+        # For now, let's assume get_session handles engine management.
+        # A more robust way might be to pass the engine or get_session directly.
+        self._session_context = get_session()  # Get the context manager
+        self.session: Optional[Session] = None
+
+    def __enter__(self) -> "SqlModelUnitOfWork":
+        """Enters the runtime context related to this object."""
+        super().__enter__()  # Log entry
+        # Enter the session context manager to get the actual session
+        self.session = self._session_context.__enter__()
+        if self.session is None:
+            # Should not happen if get_session works correctly
+            raise RuntimeError("Failed to acquire database session.")
+        self.documents = DocumentRepository(self.session)
+        return self
+
+    def commit(self) -> None:
+        """Commits changes in the current session."""
+        if self.session:
+            try:
+                self.session.commit()
+                log.debug("Unit of Work committed.")
+            except Exception as e:
+                log.exception(
+                    "Exception during UoW commit, attempting rollback.", error=str(e)
+                )
+                self.rollback()  # Attempt rollback on commit failure
+                raise  # Re-raise the exception
+        else:
+            log.warning("Commit called but session is not active.")
+
+    def rollback(self) -> None:
+        """Rolls back changes in the current session."""
+        if self.session:
+            try:
+                self.session.rollback()
+                log.debug("Unit of Work rolled back.")
+            except Exception as e:
+                # Log rollback error, but don't typically re-raise within rollback itself
+                log.exception("Exception during UoW rollback.", error=str(e))
+        else:
+            log.warning("Rollback called but session is not active.")
+
+    def close(self) -> None:
+        """Calls the exit method of the underlying session context manager."""
+        if hasattr(self._session_context, "__exit__"):
+            # Pass None to indicate normal exit for commit/rollback logic
+            # The actual exception handling is done in AbstractUnitOfWork.__exit__
+            try:
+                self._session_context.__exit__(None, None, None)
+                log.debug("Unit of Work underlying session context closed.")
+            except Exception as e:
+                # Log error during context closing if needed, but usually handled by get_session
+                log.exception(
+                    "Exception during UoW session context close.", error=str(e)
+                )
+        self.session = None  # Ensure session is cleared
+
+    # Explicit __exit__ to ensure AbstractUnitOfWork.__exit__ is called
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        super().__exit__(exc_type, exc_value, traceback)

--- a/src/reg_agent/pipelines/ingestion/run.py
+++ b/src/reg_agent/pipelines/ingestion/run.py
@@ -71,7 +71,7 @@ def run_ingestion_pipeline(source_dir: Path, db_file: Path = DEFAULT_DB_FILE):
         # --- Run Tasks Sequentially (Sync for T1, T2) --- #
 
         # Task 1: Create Records (Sync)
-        t1_inserted, t1_skipped, t1_errors = run_task_1(engine, source_dir)
+        t1_inserted, t1_skipped, t1_errors = run_task_1(source_dir)
         log.info(
             "Task 1 (Create Records) summary",
             inserted=t1_inserted,
@@ -82,7 +82,7 @@ def run_ingestion_pipeline(source_dir: Path, db_file: Path = DEFAULT_DB_FILE):
         # For now, continue even if some file reads failed.
 
         # Task 2: OCR (Sync)
-        t2_found, t2_success, t2_skipped, t2_errors = run_task_2(engine)
+        t2_found, t2_success, t2_skipped, t2_errors = run_task_2()
         log.info(
             "Task 2 (OCR) summary",
             found=t2_found,
@@ -95,7 +95,7 @@ def run_ingestion_pipeline(source_dir: Path, db_file: Path = DEFAULT_DB_FILE):
         # Task 3: Metadata Extraction (Async Call within Sync Orchestrator)
         # Run the async task 3 using asyncio.run() - It now handles its own service
         log.info("Starting Task 3 (Metadata) asynchronously...")
-        t3_found, t3_success, t3_errors = asyncio.run(run_task_3(engine))
+        t3_found, t3_success, t3_errors = asyncio.run(run_task_3())
         log.info(
             "Task 3 (Metadata) summary",
             found=t3_found,

--- a/src/reg_agent/pipelines/ingestion/tasks/task_1_create_records.py
+++ b/src/reg_agent/pipelines/ingestion/tasks/task_1_create_records.py
@@ -4,23 +4,24 @@ import datetime
 from pathlib import Path
 
 import structlog
-from sqlalchemy.engine import Engine
 
-from reg_agent.core.db.connection import get_session
+# from sqlalchemy.engine import Engine # No longer needed as arg
+# from reg_agent.core.db.connection import get_session # Replaced by UoW
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import FileRepository
+
+# from reg_agent.core.db.repositories import FileRepository # Replaced by UoW
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork  # Import UoW
 from reg_agent.utils.timing import log_task_duration
 
 log = structlog.get_logger()
 
 
 @log_task_duration("task_1_create_records")
-def run_task_1(engine: Engine, source_dir: Path):
+def run_task_1(source_dir: Path):  # Removed engine parameter
     """Scans the source directory and creates initial FileRecord entries
-    in the database for new files found (Synchronous Version).
+    in the database for new files found using Unit of Work.
 
     Args:
-        engine: The SQLAlchemy SyncEngine for database interaction.
         source_dir: The directory containing files to ingest.
 
     Returns:
@@ -31,30 +32,26 @@ def run_task_1(engine: Engine, source_dir: Path):
     error_count = 0
 
     try:
-        # Use the synchronous session manager
-        with get_session(engine=engine) as session:
-            file_repo = FileRepository(session)
-            # Pathlib iteration is sync
+        # Use the Unit of Work context manager
+        with SqlModelUnitOfWork() as uow:
+            # Access the repository via uow.documents
             for file_path in source_dir.rglob("*"):
-                # Move try block to encompass file check and processing
                 try:
                     if file_path.is_file():
                         source_path_str = str(file_path.resolve())
 
-                        # Call sync existence check directly
-                        if file_repo.exists_by_source_path(source_path_str):
+                        # Use repository from UoW
+                        if uow.documents.exists_by_source_path(source_path_str):
                             skipped_count += 1
                             log.debug("Skipped existing file", path=source_path_str)
-                            continue  # Skip to next file path
+                            continue
 
-                        # File I/O and stat remain sync
                         file_stat = file_path.stat()
                         filename = file_path.name
                         size_bytes = file_stat.st_size
                         last_modified_ts = datetime.datetime.fromtimestamp(
                             file_stat.st_mtime, tz=datetime.timezone.utc
                         )
-                        # Reading blob can also cause OSError
                         with open(file_path, "rb") as f:
                             blob_content = f.read()
 
@@ -69,17 +66,14 @@ def run_task_1(engine: Engine, source_dir: Path):
                             status=FileStatus.PENDING_PROCESS,
                         )
 
-                        # Call sync add directly
-                        session.add(new_record)
+                        # Use repository add method from UoW
+                        uow.documents.add(new_record)
                         inserted_count += 1
                         log.debug(
-                            "Staged new FileRecord",
+                            "Staged new FileRecord (pending UoW commit)",
                             path=source_path_str,
                             record_id=new_record.id,
                         )
-
-                    # If it's not a file (e.g., a directory), just continue the loop
-                    # else: pass # Implicitly continue
 
                 except OSError as e:
                     error_count += 1
@@ -95,18 +89,13 @@ def run_task_1(engine: Engine, source_dir: Path):
                         path=str(file_path),
                         error=str(e),
                     )
-                # Continue to the next file_path even if an error occurred
-
-            # Commit happens automatically via sync context manager exit
+            # Commit happens automatically on successful exit of the 'with uow:' block
 
     except Exception as e:
-        # This catches errors initializing the session or repository
-        error_count += 1  # Or should this be handled differently?
-        log.exception(
-            "Error during Task 1 session setup or main loop exit", error=str(e)
-        )
+        # This catches errors initializing the UoW or during its exit
+        error_count += 1
+        log.exception("Error during Task 1 Unit of Work execution", error=str(e))
 
-    # Log final summary counts
     log.info(
         "Task 1 Summary",
         inserted=inserted_count,

--- a/src/reg_agent/pipelines/ingestion/tasks/task_2_ocr.py
+++ b/src/reg_agent/pipelines/ingestion/tasks/task_2_ocr.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from typing import Optional
 
 import structlog
-from sqlalchemy.engine import Engine
 
-from reg_agent.core.db.connection import get_session
+# from sqlalchemy.engine import Engine # Removed
+# from reg_agent.core.db.connection import get_session # Replaced by UoW
 from reg_agent.core.db.models import FileStatus
-from reg_agent.core.db.repositories import FileRepository
+
+# from reg_agent.core.db.repositories import FileRepository # Replaced by UoW
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork  # Import UoW
 from reg_agent.services.ocr_service import OcrService
 from reg_agent.utils.timing import log_task_duration
 
@@ -16,13 +18,10 @@ log = structlog.get_logger()
 
 
 @log_task_duration("task_2_ocr")
-def run_task_2(engine: Engine):
-    """Performs OCR on records with status PENDING_PROCESS (Synchronous Version).
+def run_task_2():  # Removed engine parameter
+    """Performs OCR on records with status PENDING_PROCESS using UoW.
 
     Updates status to PENDING_METADATA, SKIPPED_OCR, or FAILED_OCR.
-
-    Args:
-        engine: The SQLAlchemy SyncEngine for database interaction.
 
     Returns:
         Tuple[int, int, int, int]: found_count, success_count, skipped_count, error_count
@@ -39,9 +38,12 @@ def run_task_2(engine: Engine):
             log.warning("OCR Service converter not initialized. Skipping Task 2.")
             return 0, 0, 0, 0
 
-        with get_session(engine=engine) as session:
-            file_repo = FileRepository(session)
-            records_to_ocr = file_repo.get_records_by_status(FileStatus.PENDING_PROCESS)
+        # Use the Unit of Work context manager
+        with SqlModelUnitOfWork() as uow:
+            # Access the repository via uow.documents
+            records_to_ocr = uow.documents.get_records_by_status(
+                FileStatus.PENDING_PROCESS
+            )
             records_found = len(records_to_ocr)
             log.info(f"Task 2: Found {records_found} records for OCR.")
 
@@ -60,41 +62,39 @@ def run_task_2(engine: Engine):
                     extracted_markdown = ocr_service.extract_markdown_from_file(
                         Path(record.source_path)
                     )
-                    record_modified = False
+                    # Modify record attributes directly; UoW tracks changes
                     if extracted_markdown:
                         record.extracted_text = extracted_markdown
                         record.status = FileStatus.PENDING_METADATA
                         success_count += 1
-                        record_modified = True
                     else:
                         record.status = FileStatus.SKIPPED_OCR
                         skipped_count += 1
-                        record_modified = True
 
-                    if record_modified:
-                        session.add(record)
-                        log.debug(
-                            "Staged record update",
-                            record_id=record.id,
-                            status=record.status,
-                        )
+                    log.debug(
+                        "Processed record, staged status update",
+                        record_id=record.id,
+                        status=record.status,
+                    )
 
                 except Exception as e:
                     error_count += 1
+                    # Modify record status; UoW tracks changes
                     record.status = FileStatus.FAILED_OCR
-                    session.add(record)
                     log.warning(
                         "OCR Error, staging FAILED_OCR status",
                         record_id=record.id,
                         path=record.source_path,
                         error=str(e),
                     )
-
-            # Commit happens automatically via sync context manager exit
+            # Commit happens automatically on successful exit of 'with uow:'
 
     except Exception as e:
-        error_count += 1
-        log.exception("Error during Task 2 session or execution", error=str(e))
+        # This catches errors initializing the UoW, OCR service, or during UoW commit
+        error_count += (
+            1  # Ensure error is counted if exception happens outside the loop
+        )
+        log.exception("Error during Task 2 processing", error=str(e))
 
     # Log final summary counts
     log.info(

--- a/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
+++ b/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
@@ -42,9 +42,11 @@ async def run_task_3(): # Removed engine parameter
     try:
         # Wrap entire fetch and process logic in a single UoW
         with SqlModelUnitOfWork() as uow:
-            # Fetch records inside the UoW
+            # Fetch records inside the UoW - Include FAILED_METADATA for retry
+            statuses_to_process = [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
+            log.info("Querying for records with statuses", statuses=statuses_to_process)
             records_to_process = uow.documents.get_records_by_status(
-                FileStatus.PENDING_METADATA
+                statuses_to_process # Pass list as positional argument
             )
             records_found = len(records_to_process)
             log.info(f"Task 3: Found {records_found} records for metadata extraction.")

--- a/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
+++ b/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
@@ -23,6 +23,7 @@ async def run_task_3():  # Removed engine parameter
 
     Initializes MetadataExtractionService once and processes records within a single UoW.
     Uses synchronous database operations tracked by UoW within the async function.
+    Ensures MetadataExtractionService is closed if initialized.
 
     Returns:
         Tuple[int, int, int]: found_count, success_count, error_count
@@ -30,112 +31,114 @@ async def run_task_3():  # Removed engine parameter
     records_found = 0
     success_count = 0
     error_count = 0
-
-    # Initialize service once outside the UoW and loop
-    metadata_service: Optional[MetadataExtractionService] = None
-    try:
-        metadata_service = MetadataExtractionService()
-        log.info("MetadataExtractionService initialized for Task 3.")
-    except Exception as service_init_err:
-        log.exception(
-            "Failed to initialize MetadataExtractionService",
-            error=str(service_init_err),
-        )
-        # Cannot proceed without the service
-        return 0, 0, 1  # Return 1 error for service init failure
+    metadata_service: Optional[MetadataExtractionService] = None # Initialize outside try
 
     try:
-        # Wrap entire fetch and process logic in a single UoW
-        with SqlModelUnitOfWork() as uow:
-            # Fetch records inside the UoW - Include FAILED_METADATA for retry
-            statuses_to_process = [
-                FileStatus.PENDING_METADATA,
-                FileStatus.FAILED_METADATA,
-            ]
-            log.info("Querying for records with statuses", statuses=statuses_to_process)
-            records_to_process = uow.documents.get_records_by_status(
-                statuses_to_process  # Pass list as positional argument
+        # --- Initialize Service --- #
+        try:
+            metadata_service = MetadataExtractionService()
+            log.info("MetadataExtractionService initialized for Task 3.")
+        except Exception as service_init_err:
+            log.exception(
+                "Failed to initialize MetadataExtractionService",
+                error=str(service_init_err),
             )
-            records_found = len(records_to_process)
-            log.info(f"Task 3: Found {records_found} records for metadata extraction.")
+            # Cannot proceed without the service
+            error_count = 1 # Set error count for service init failure
+            return 0, 0, error_count
 
-            if not records_to_process:
-                # Still log summary, even if no records found
-                log.info(
-                    "Task 3 Summary",
-                    found=records_found,
-                    success=success_count,
-                    errors=error_count,
+        # --- Process Records using UoW --- #
+        try:
+            # Wrap entire fetch and process logic in a single UoW
+            with SqlModelUnitOfWork() as uow:
+                # Fetch records inside the UoW - Include FAILED_METADATA for retry
+                statuses_to_process = [
+                    FileStatus.PENDING_METADATA,
+                    FileStatus.FAILED_METADATA,
+                ]
+                log.info("Querying for records with statuses", statuses=statuses_to_process)
+                records_to_process = uow.documents.get_records_by_status(
+                    statuses_to_process  # Pass list as positional argument
                 )
-                return records_found, success_count, error_count  # Exit early
+                records_found = len(records_to_process)
+                log.info(f"Task 3: Found {records_found} records for metadata extraction.")
 
-            for record in records_to_process:
-                await asyncio.sleep(2)  # Keep the delay
+                if not records_to_process:
+                    pass # Let summary log outside the loop handle this
+                else:
+                    for record in records_to_process:
+                        await asyncio.sleep(2)  # Keep the delay
 
-                if not record.extracted_text:
-                    log.warning(
-                        "Skipping metadata: Record has no extracted text",
-                        record_id=record.id,
-                    )
-                    # Update status directly; UoW tracks the change
-                    record.status = FileStatus.FAILED_UNKNOWN
-                    log.info("Staging status to FAILED_UNKNOWN", record_id=record.id)
-                    error_count += 1
-                    continue  # Move to the next record
+                        if not record.extracted_text:
+                            log.warning(
+                                "Skipping metadata: Record has no extracted text",
+                                record_id=record.id,
+                            )
+                            record.status = FileStatus.FAILED_UNKNOWN
+                            log.info("Staging status to FAILED_UNKNOWN", record_id=record.id)
+                            error_count += 1
+                            continue
 
-                # --- Call Metadata Service --- #
-                try:
-                    extracted_meta_model = await metadata_service.extract_metadata(
-                        record.extracted_text
-                    )
+                        # --- Call Metadata Service --- #
+                        try:
+                            # Check service exists before calling (should always here)
+                            if not metadata_service:
+                                raise RuntimeError("Metadata service not initialized unexpectedly")
 
-                    # --- Update record based on result; UoW tracks changes --- #
-                    if extracted_meta_model:
-                        record.status = FileStatus.COMPLETED
-                        record.meta_data = extracted_meta_model.model_dump()
-                        log.debug(
-                            "Staging COMPLETED status and metadata", record_id=record.id
-                        )
-                        success_count += 1
-                    else:
-                        record.status = FileStatus.FAILED_METADATA
-                        log.debug(
-                            "Staging FAILED_METADATA status (API returned None)",
-                            record_id=record.id,
-                        )
-                        error_count += 1
-                    # No explicit session.add(record) needed here
-                    # --- End Update --- #
+                            extracted_meta_model = await metadata_service.extract_metadata(
+                                record.extracted_text
+                            )
 
-                except Exception as e:
-                    # Handle API/Service errors during extraction for *this* record
-                    log.warning(
-                        "Metadata extraction API/Service error for record",
-                        record_id=record.id,
-                        path=record.source_path,
-                        error=str(e),
-                        exc_info=False,
-                    )
-                    # Update status directly; UoW tracks the change
-                    record.status = FileStatus.FAILED_METADATA
-                    log.debug(
-                        "Staging FAILED_METADATA status after API error",
-                        record_id=record.id,
-                    )
-                    error_count += 1
-                    # No explicit session.add(record) needed here
+                            # --- Update record based on result; UoW tracks changes --- #
+                            if extracted_meta_model:
+                                record.status = FileStatus.COMPLETED
+                                record.meta_data = extracted_meta_model.model_dump()
+                                log.debug(
+                                    "Staging COMPLETED status and metadata", record_id=record.id
+                                )
+                                success_count += 1
+                            else:
+                                record.status = FileStatus.FAILED_METADATA
+                                log.debug(
+                                    "Staging FAILED_METADATA status (API returned None)",
+                                    record_id=record.id,
+                                )
+                                error_count += 1
 
-            # Commit for all processed records happens automatically on successful exit of 'with uow:'
+                        except Exception as e:
+                            log.warning(
+                                "Metadata extraction API/Service error for record",
+                                record_id=record.id,
+                                path=record.source_path,
+                                error=str(e),
+                                exc_info=False,
+                            )
+                            record.status = FileStatus.FAILED_METADATA
+                            log.debug(
+                                "Staging FAILED_METADATA status after API error",
+                                record_id=record.id,
+                            )
+                            error_count += 1
 
-    except Exception as e:
-        # This catches errors initializing the UoW or during the UoW commit/rollback
-        log.exception("Error during Task 3 Unit of Work execution", error=str(e))
-        # We don't know how many records were intended, return initial counts + 1 general error
-        # Note: Individual record errors inside the loop are already counted.
-        # This error count might be slightly off if the commit fails after some successes.
-        # A more robust approach might involve tracking IDs intended vs committed.
-        error_count += 1  # Add error for the UoW context issue
+        except Exception as e:
+            # Catches errors initializing UoW or during UoW commit/rollback
+            log.exception("Error during Task 3 Unit of Work execution", error=str(e))
+            error_count += 1
 
+    finally:
+        # --- Ensure Service Cleanup --- #
+        if metadata_service and hasattr(metadata_service, 'close'):
+            try:
+                log.info("Attempting to close MetadataExtractionService client.")
+                await metadata_service.close()
+                log.info("MetadataExtractionService client closed successfully.")
+            except Exception as close_err:
+                log.warning(
+                    "Error closing MetadataExtractionService client",
+                    error=str(close_err)
+                )
+
+    # --- Log Final Summary --- #
     log.info(
         "Task 3 Summary",
         found=records_found,

--- a/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
+++ b/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
@@ -4,11 +4,11 @@ import asyncio
 from typing import Optional
 
 import structlog
-from sqlalchemy.engine import Engine
-
-from reg_agent.core.db.connection import get_session
+# from sqlalchemy.engine import Engine # Removed
+# from reg_agent.core.db.connection import get_session # Replaced by UoW
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import FileRepository
+# from reg_agent.core.db.repositories import FileRepository # Replaced by UoW
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork # Import UoW
 from reg_agent.services.metadata_service import MetadataExtractionService
 from reg_agent.utils.timing import log_task_duration
 
@@ -16,14 +16,11 @@ log = structlog.get_logger()
 
 
 @log_task_duration("task_3_metadata")
-async def run_task_3(engine: Engine):
-    """Extracts metadata for records with status PENDING_METADATA.
+async def run_task_3(): # Removed engine parameter
+    """Extracts metadata for records with status PENDING_METADATA using UoW.
 
-    Initializes MetadataExtractionService internally per record.
-    Uses synchronous database operations within the async function.
-
-    Args:
-        engine: The SQLAlchemy synchronous Engine for database interaction.
+    Initializes MetadataExtractionService once and processes records within a single UoW.
+    Uses synchronous database operations tracked by UoW within the async function.
 
     Returns:
         Tuple[int, int, int]: found_count, success_count, error_count
@@ -31,191 +28,110 @@ async def run_task_3(engine: Engine):
     records_found = 0
     success_count = 0
     error_count = 0
-    records_processed_ids = set()
 
-    # Initial fetch needs its own session block
-    records_data = []  # Initialize records_data
+    # Initialize service once outside the UoW and loop
+    metadata_service: Optional[MetadataExtractionService] = None
     try:
-        with get_session(engine=engine) as session:
-            file_repo = FileRepository(session)
-            records_to_process = file_repo.get_records_by_status(
+        metadata_service = MetadataExtractionService()
+        log.info("MetadataExtractionService initialized for Task 3.")
+    except Exception as service_init_err:
+        log.exception("Failed to initialize MetadataExtractionService", error=str(service_init_err))
+        # Cannot proceed without the service
+        return 0, 0, 1 # Return 1 error for service init failure
+
+    try:
+        # Wrap entire fetch and process logic in a single UoW
+        with SqlModelUnitOfWork() as uow:
+            # Fetch records inside the UoW
+            records_to_process = uow.documents.get_records_by_status(
                 FileStatus.PENDING_METADATA
             )
             records_found = len(records_to_process)
-            records_data = [
-                (r.id, r.source_path, r.extracted_text) for r in records_to_process
-            ]
-        log.info(f"Task 3: Found {records_found} records for metadata extraction.")
-    except Exception as e:
-        log.exception("Error fetching records for Task 3", error=str(e))
-        return 0, 0, 0
+            log.info(f"Task 3: Found {records_found} records for metadata extraction.")
 
-    if not records_data:
-        log.info(
-            "Task 3 Summary",
-            found=records_found,
-            success=success_count,
-            errors=error_count,
-        )
-        return records_found, success_count, error_count
-
-    for record_id, source_path, extracted_text in records_data:
-        if record_id in records_processed_ids:
-            continue
-
-        await asyncio.sleep(2)  # Delay between API calls
-
-        if not extracted_text:
-            log.warning(
-                "Skipping metadata: Record has no extracted text",
-                record_id=record_id,
-            )
-            try:
-                with get_session(engine=engine) as update_session:
-                    # Fetch the specific record to update
-                    record = update_session.get(FileRecord, record_id)
-                    if record:
-                        record.status = FileStatus.FAILED_UNKNOWN
-                        update_session.add(record)
-                        # Commit happens on session exit
-                        log.info(
-                            "Updating status to FAILED_UNKNOWN", record_id=record_id
-                        )
-                    else:
-                        log.error(
-                            "Could not find record to update status to FAILED_UNKNOWN",
-                            record_id=record_id,
-                        )
-            except Exception as commit_err:
-                log.error(
-                    "Failed session/commit for FAILED_UNKNOWN status",
-                    record_id=record_id,
-                    error=str(commit_err),
+            if not records_to_process:
+                # Still log summary, even if no records found
+                log.info(
+                    "Task 3 Summary",
+                    found=records_found,
+                    success=success_count,
+                    errors=error_count,
                 )
-            error_count += 1
-            records_processed_ids.add(record_id)
-            continue
+                return records_found, success_count, error_count # Exit early
 
-        # --- Service Init & API Call per Record --- #
-        metadata_service: Optional[MetadataExtractionService] = None
-        try:
-            # Initialize service inside the loop
-            metadata_service = MetadataExtractionService()
-            log.info(
-                "MetadataExtractionService initialized for record", record_id=record_id
-            )
+            for record in records_to_process:
+                await asyncio.sleep(2)  # Keep the delay
 
-            extracted_meta_model = await metadata_service.extract_metadata(
-                extracted_text
-            )
-
-            # --- Sync DB Update --- #
-            update_status = None
-            update_metadata = None
-            commit_log_msg = ""
-
-            if extracted_meta_model:
-                update_status = FileStatus.COMPLETED
-                update_metadata = extracted_meta_model.model_dump()
-                commit_log_msg = "Committing COMPLETED status and metadata"
-                success_count += 1
-            else:
-                update_status = FileStatus.FAILED_METADATA
-                commit_log_msg = "Committing FAILED_METADATA status (API returned None)"
-                error_count += 1
-
-            try:
-                with get_session(engine=engine) as update_session:
-                    record = update_session.get(FileRecord, record_id)
-                    if record:
-                        log.debug(commit_log_msg, record_id=record_id)
-                        record.status = update_status
-                        if update_metadata:
-                            record.meta_data = update_metadata
-                        update_session.add(record)
-                        # Commit happens on session exit
-                    else:
-                        log.error(
-                            "Could not find record to update metadata status",
-                            record_id=record_id,
-                            target_status=update_status,
-                        )
-                        # Adjust counts if record vanished?
-                        if update_status == FileStatus.COMPLETED:
-                            success_count -= 1
-                        else:
-                            error_count -= 1  # Decrement if we counted it
-                        error_count += 1  # Add error for missing record
-                        continue  # Skip to next record
-
-            except Exception as commit_err:
-                log.error(
-                    "Failed session/commit updating metadata status",
-                    record_id=record_id,
-                    error=str(commit_err),
-                )
-                # Adjust counts as commit failed
-                if update_status == FileStatus.COMPLETED:
-                    success_count -= 1
-                else:
-                    error_count -= 1  # Decrement if we counted it
-                error_count += 1  # Add error for the commit failure
-            # --- End Sync DB Update --- #
-
-        except Exception as e:
-            # Handle API/Service errors
-            log.warning(
-                "Metadata extraction API/Service error for record",
-                record_id=record_id,
-                path=source_path,
-                error=str(e),
-                exc_info=False,
-            )
-            # --- Sync DB Update for API Error --- #
-            try:
-                with get_session(engine=engine) as update_session:
-                    record = update_session.get(FileRecord, record_id)
-                    if record:
-                        log.debug(
-                            "Committing FAILED_METADATA status after API error",
-                            record_id=record_id,
-                        )
-                        record.status = FileStatus.FAILED_METADATA
-                        update_session.add(record)
-                        # Commit happens on session exit
-                    else:
-                        log.error(
-                            "Could not find record to update status after API error",
-                            record_id=record_id,
-                        )
-            except Exception as commit_err:
-                log.error(
-                    "Failed session/commit updating FAILED_METADATA status after API error",
-                    record_id=record_id,
-                    error=str(commit_err),
-                )
-            error_count += 1
-            # --- End Sync DB Update for API Error --- #
-
-        finally:
-            # --- Close Service Instance --- #
-            if metadata_service:
-                try:
-                    await metadata_service.close()
+                if not record.extracted_text:
+                    log.warning(
+                        "Skipping metadata: Record has no extracted text",
+                        record_id=record.id,
+                    )
+                    # Update status directly; UoW tracks the change
+                    record.status = FileStatus.FAILED_UNKNOWN
                     log.info(
-                        "MetadataExtractionService closed for record",
-                        record_id=record_id,
+                        "Staging status to FAILED_UNKNOWN", record_id=record.id
                     )
-                except Exception as close_err:
-                    log.error(
-                        "Failed to close service for record",
-                        record_id=record_id,
-                        error=str(close_err),
-                    )
-            records_processed_ids.add(record_id)
+                    error_count += 1
+                    continue # Move to the next record
 
-    # Log final summary counts
+                # --- Call Metadata Service --- #
+                try:
+                    extracted_meta_model = await metadata_service.extract_metadata(
+                        record.extracted_text
+                    )
+
+                    # --- Update record based on result; UoW tracks changes --- #
+                    if extracted_meta_model:
+                        record.status = FileStatus.COMPLETED
+                        record.meta_data = extracted_meta_model.model_dump()
+                        log.debug(
+                            "Staging COMPLETED status and metadata", record_id=record.id
+                        )
+                        success_count += 1
+                    else:
+                        record.status = FileStatus.FAILED_METADATA
+                        log.debug(
+                            "Staging FAILED_METADATA status (API returned None)",
+                            record_id=record.id,
+                        )
+                        error_count += 1
+                    # No explicit session.add(record) needed here
+                    # --- End Update --- #
+
+                except Exception as e:
+                    # Handle API/Service errors during extraction for *this* record
+                    log.warning(
+                        "Metadata extraction API/Service error for record",
+                        record_id=record.id,
+                        path=record.source_path,
+                        error=str(e),
+                        exc_info=False,
+                    )
+                    # Update status directly; UoW tracks the change
+                    record.status = FileStatus.FAILED_METADATA
+                    log.debug(
+                        "Staging FAILED_METADATA status after API error",
+                        record_id=record.id,
+                    )
+                    error_count += 1
+                    # No explicit session.add(record) needed here
+
+            # Commit for all processed records happens automatically on successful exit of 'with uow:'
+
+    except Exception as e:
+        # This catches errors initializing the UoW or during the UoW commit/rollback
+        log.exception("Error during Task 3 Unit of Work execution", error=str(e))
+        # We don't know how many records were intended, return initial counts + 1 general error
+        # Note: Individual record errors inside the loop are already counted.
+        # This error count might be slightly off if the commit fails after some successes.
+        # A more robust approach might involve tracking IDs intended vs committed.
+        error_count += 1 # Add error for the UoW context issue
+
     log.info(
-        "Task 3 Summary", found=records_found, success=success_count, errors=error_count
+        "Task 3 Summary",
+        found=records_found,
+        success=success_count,
+        errors=error_count,
     )
     return records_found, success_count, error_count

--- a/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
+++ b/src/reg_agent/pipelines/ingestion/tasks/task_3_metadata.py
@@ -4,11 +4,13 @@ import asyncio
 from typing import Optional
 
 import structlog
+
 # from sqlalchemy.engine import Engine # Removed
 # from reg_agent.core.db.connection import get_session # Replaced by UoW
-from reg_agent.core.db.models import FileRecord, FileStatus
+from reg_agent.core.db.models import FileStatus
+
 # from reg_agent.core.db.repositories import FileRepository # Replaced by UoW
-from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork # Import UoW
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork  # Import UoW
 from reg_agent.services.metadata_service import MetadataExtractionService
 from reg_agent.utils.timing import log_task_duration
 
@@ -16,7 +18,7 @@ log = structlog.get_logger()
 
 
 @log_task_duration("task_3_metadata")
-async def run_task_3(): # Removed engine parameter
+async def run_task_3():  # Removed engine parameter
     """Extracts metadata for records with status PENDING_METADATA using UoW.
 
     Initializes MetadataExtractionService once and processes records within a single UoW.
@@ -35,18 +37,24 @@ async def run_task_3(): # Removed engine parameter
         metadata_service = MetadataExtractionService()
         log.info("MetadataExtractionService initialized for Task 3.")
     except Exception as service_init_err:
-        log.exception("Failed to initialize MetadataExtractionService", error=str(service_init_err))
+        log.exception(
+            "Failed to initialize MetadataExtractionService",
+            error=str(service_init_err),
+        )
         # Cannot proceed without the service
-        return 0, 0, 1 # Return 1 error for service init failure
+        return 0, 0, 1  # Return 1 error for service init failure
 
     try:
         # Wrap entire fetch and process logic in a single UoW
         with SqlModelUnitOfWork() as uow:
             # Fetch records inside the UoW - Include FAILED_METADATA for retry
-            statuses_to_process = [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
+            statuses_to_process = [
+                FileStatus.PENDING_METADATA,
+                FileStatus.FAILED_METADATA,
+            ]
             log.info("Querying for records with statuses", statuses=statuses_to_process)
             records_to_process = uow.documents.get_records_by_status(
-                statuses_to_process # Pass list as positional argument
+                statuses_to_process  # Pass list as positional argument
             )
             records_found = len(records_to_process)
             log.info(f"Task 3: Found {records_found} records for metadata extraction.")
@@ -59,7 +67,7 @@ async def run_task_3(): # Removed engine parameter
                     success=success_count,
                     errors=error_count,
                 )
-                return records_found, success_count, error_count # Exit early
+                return records_found, success_count, error_count  # Exit early
 
             for record in records_to_process:
                 await asyncio.sleep(2)  # Keep the delay
@@ -71,11 +79,9 @@ async def run_task_3(): # Removed engine parameter
                     )
                     # Update status directly; UoW tracks the change
                     record.status = FileStatus.FAILED_UNKNOWN
-                    log.info(
-                        "Staging status to FAILED_UNKNOWN", record_id=record.id
-                    )
+                    log.info("Staging status to FAILED_UNKNOWN", record_id=record.id)
                     error_count += 1
-                    continue # Move to the next record
+                    continue  # Move to the next record
 
                 # --- Call Metadata Service --- #
                 try:
@@ -128,7 +134,7 @@ async def run_task_3(): # Removed engine parameter
         # Note: Individual record errors inside the loop are already counted.
         # This error count might be slightly off if the commit fails after some successes.
         # A more robust approach might involve tracking IDs intended vs committed.
-        error_count += 1 # Add error for the UoW context issue
+        error_count += 1  # Add error for the UoW context issue
 
     log.info(
         "Task 3 Summary",

--- a/src/reg_agent/services/metadata_service.py
+++ b/src/reg_agent/services/metadata_service.py
@@ -32,7 +32,7 @@ from reg_agent.schemas.metadata import (
 
 # --- Constants --- #
 # Define longer timeouts and more retries
-REQUEST_TIMEOUT_SECONDS = 180.0
+REQUEST_TIMEOUT_SECONDS = 360.0
 CONNECT_TIMEOUT_SECONDS = 20.0  # Keep connect timeout reasonable
 MAX_RETRIES = 3
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ def configure_structlog_for_pytest():
 
 # --- Added DB Fixtures ---
 
+
 @pytest.fixture(scope="function")  # Use function scope for isolation
 def test_db_path(tmp_path: Path) -> Path:
     """Provides a temporary path for the test database."""

--- a/tests/core/db/test_repositories.py
+++ b/tests/core/db/test_repositories.py
@@ -76,7 +76,7 @@ def test_get_by_id_exists(session: Session, repo: DocumentRepository):
     session.add(record)  # Add directly to session for setup
     session.commit()
 
-    retrieved_record = repo.get_by_id(record_id)
+    retrieved_record = repo.get(record_id)
 
     assert retrieved_record is not None
     assert retrieved_record.id == record_id
@@ -86,7 +86,7 @@ def test_get_by_id_exists(session: Session, repo: DocumentRepository):
 def test_get_by_id_not_exists(repo: DocumentRepository):
     """Test retrieving a non-existent record by ID returns None."""
     non_existent_id = uuid.uuid4()
-    retrieved_record = repo.get_by_id(non_existent_id)
+    retrieved_record = repo.get(non_existent_id)
     assert retrieved_record is None
 
 

--- a/tests/core/db/test_repositories.py
+++ b/tests/core/db/test_repositories.py
@@ -4,266 +4,171 @@ Unit tests for the repository classes.
 
 import datetime
 import uuid
-from unittest.mock import MagicMock
+from typing import Generator
+from datetime import timezone
 
 import pytest
-from sqlmodel import Session
+from sqlmodel import Session, SQLModel, create_engine
 
 # Modules/Classes to test
 from reg_agent.core.db import models
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import FileRepository
+from reg_agent.core.db.repositories import DocumentRepository
 
 # Configure structlog for testing (if capturing logs)
 # structlog.configure(processors=[structlog.testing.LogCapture()])
 
 
-@pytest.fixture
-def mock_session() -> MagicMock:
-    """Provides a mock SQLModel Session."""
-    # Create a MagicMock instance that simulates the Session
-    session = MagicMock(spec=Session)
-    # Mock the .exec() method chain
-    mock_exec = MagicMock()
-    session.exec.return_value = mock_exec
-    # Set default return values for common methods (can be overridden in tests)
-    mock_exec.first.return_value = None
-    mock_exec.one_or_none.return_value = None
-    mock_exec.all.return_value = []
-    return session
+@pytest.fixture(name="session")
+def session_fixture() -> Generator[Session, None, None]:
+    """Creates a clean in-memory SQLite database session for each test."""
+    # Use in-memory DuckDB for testing
+    engine = create_engine("duckdb:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    # Tables are dropped implicitly when the in-memory DB is closed
 
 
-@pytest.fixture
-def file_repository(mock_session: MagicMock) -> FileRepository:
-    """Provides a FileRepository instance with a mock session."""
-    return FileRepository(session=mock_session)
+@pytest.fixture(name="repo")
+def repo_fixture(session: Session) -> DocumentRepository:
+    """Provides a DocumentRepository instance initialized with the test session."""
+    return DocumentRepository(session=session)
 
 
-@pytest.fixture
-def sample_file_record() -> models.FileRecord:
-    """Provides a sample FileRecord for testing."""
-    return models.FileRecord(
-        id=uuid.uuid4(),  # Generate a real UUID
-        source_path="/test/path/sample.pdf",
-        filename="sample.pdf",
-        blob=b"sample content",
-        extracted_text="Sample text",
-        size_bytes=14,
-        last_modified_ts=datetime.datetime.now(datetime.timezone.utc),
+def create_test_record(
+    source_path: str = "/test/file.txt",
+    status: FileStatus = FileStatus.PENDING_PROCESS,
+    extracted_text: str | None = None,
+    meta_data: dict | None = None,
+    record_id: uuid.UUID | None = None, # Allow specifying ID for testing get_by_id
+) -> FileRecord:
+    """Helper function to create a FileRecord with defaults."""
+    return FileRecord(
+        id=record_id or uuid.uuid4(),
+        source_path=source_path,
+        filename=source_path.split("/")[-1],
+        blob=b"test content",
+        size_bytes=len(b"test content"),
+        last_modified_ts=datetime.datetime.now(timezone.utc),
+        extracted_text=extracted_text,
+        meta_data=meta_data,
+        status=status,
     )
 
 
-def test_repository_init(mock_session: MagicMock):
-    """Tests FileRepository initialization."""
-    repo = FileRepository(session=mock_session)
-    assert repo.session is mock_session
+def test_add_record(session: Session, repo: DocumentRepository):
+    """Test adding a record successfully."""
+    record = create_test_record(source_path="/add/test.txt")
+    repo.add(record)
+    session.commit()  # Commit needed as repo.add only adds to session
+
+    # Verify record was added by retrieving it
+    added_record = session.get(FileRecord, record.id)
+    assert added_record is not None
+    assert added_record.id == record.id
+    assert added_record.source_path == "/add/test.txt"
 
 
-def test_add_success(
-    file_repository: FileRepository,
-    mock_session: MagicMock,
-    sample_file_record: models.FileRecord,
-):
-    """Tests successfully adding a record."""
-    file_repository.add(sample_file_record)
-    # Verify that session.add was called exactly once with the sample record
-    mock_session.add.assert_called_once_with(sample_file_record)
+def test_get_by_id_exists(session: Session, repo: DocumentRepository):
+    """Test retrieving an existing record by ID."""
+    record_id = uuid.uuid4()
+    record = create_test_record(record_id=record_id, source_path="/get/exists.txt")
+    session.add(record) # Add directly to session for setup
+    session.commit()
+
+    retrieved_record = repo.get_by_id(record_id)
+
+    assert retrieved_record is not None
+    assert retrieved_record.id == record_id
+    assert retrieved_record.source_path == "/get/exists.txt"
 
 
-def test_add_failure(
-    file_repository: FileRepository,
-    mock_session: MagicMock,
-    sample_file_record: models.FileRecord,
-):
-    """Tests handling of exception during add."""
-    # Configure the mock session.add to raise an exception
-    mock_session.add.side_effect = Exception("DB Error")
-
-    # Assert that the repository re-raises the exception
-    with pytest.raises(Exception, match="DB Error"):
-        file_repository.add(sample_file_record)
-
-    mock_session.add.assert_called_once_with(sample_file_record)
+def test_get_by_id_not_exists(repo: DocumentRepository):
+    """Test retrieving a non-existent record by ID returns None."""
+    non_existent_id = uuid.uuid4()
+    retrieved_record = repo.get_by_id(non_existent_id)
+    assert retrieved_record is None
 
 
-def test_exists_by_source_path_found(
-    file_repository: FileRepository,
-    mock_session: MagicMock,
-    sample_file_record: models.FileRecord,
-):
-    """Tests exists_by_source_path when the record is found."""
-    test_path = sample_file_record.source_path
-    # Configure the mock session chain to return the sample record
-    mock_session.exec.return_value.first.return_value = sample_file_record
+def test_exists_by_source_path_true(session: Session, repo: DocumentRepository):
+    """Test checking existence for a path that exists."""
+    source_path = "/exists/true.txt"
+    record = create_test_record(source_path=source_path)
+    session.add(record)
+    session.commit()
 
-    exists = file_repository.exists_by_source_path(test_path)
-
-    assert exists is True
-    # Verify that session.exec(select(...)).first() was called
-    # We might need more specific assertion on the statement if necessary
-    mock_session.exec.assert_called_once()
-    mock_session.exec.return_value.first.assert_called_once()
+    assert repo.exists_by_source_path(source_path) is True
 
 
-def test_exists_by_source_path_not_found(
-    file_repository: FileRepository, mock_session: MagicMock
-):
-    """Tests exists_by_source_path when the record is not found."""
-    test_path = "/non/existent/path.txt"
-    # Ensure the mock session chain returns None (default in fixture, but explicit here)
-    mock_session.exec.return_value.first.return_value = None
-
-    exists = file_repository.exists_by_source_path(test_path)
-
-    assert exists is False
-    mock_session.exec.assert_called_once()
-    mock_session.exec.return_value.first.assert_called_once()
+def test_exists_by_source_path_false(repo: DocumentRepository):
+    """Test checking existence for a path that does not exist."""
+    source_path = "/exists/false.txt"
+    assert repo.exists_by_source_path(source_path) is False
 
 
-def test_exists_by_source_path_failure(
-    file_repository: FileRepository, mock_session: MagicMock
-):
-    """Tests handling of exception during exists_by_source_path."""
-    test_path = "/error/path.txt"
-    # Configure the mock session.exec to raise an exception
-    mock_session.exec.side_effect = Exception("Query Error")
+def test_get_records_by_status(session: Session, repo: DocumentRepository):
+    """Test retrieving records based on their status."""
+    rec1 = create_test_record(source_path="/status/1.txt", status=FileStatus.COMPLETED)
+    rec2 = create_test_record(source_path="/status/2.txt", status=FileStatus.PENDING_PROCESS)
+    rec3 = create_test_record(source_path="/status/3.txt", status=FileStatus.COMPLETED)
+    session.add_all([rec1, rec2, rec3])
+    session.commit()
 
-    # Assert that the repository re-raises the exception
-    with pytest.raises(Exception, match="Query Error"):
-        file_repository.exists_by_source_path(test_path)
+    completed_records = repo.get_records_by_status(FileStatus.COMPLETED)
+    pending_records = repo.get_records_by_status(FileStatus.PENDING_PROCESS)
+    failed_records = repo.get_records_by_status(FileStatus.FAILED_OCR)
 
-    # Verify exec was called
-    mock_session.exec.assert_called_once()
-
-
-def test_get_records_by_status_found(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    # Dummy records to be returned
-    records = [
-        FileRecord(
-            id=uuid.uuid4(), source_path="/p1.txt", status=FileStatus.PENDING_PROCESS
-        ),
-        FileRecord(
-            id=uuid.uuid4(), source_path="/p2.txt", status=FileStatus.PENDING_PROCESS
-        ),
-    ]
-    # Mock session.exec(...).all() to return the dummy records
-    mock_result = MagicMock()
-    mock_result.all.return_value = records
-    mock_session.exec.return_value = mock_result
-
-    found_records = repo.get_records_by_status(FileStatus.PENDING_PROCESS)
-
-    assert found_records == records
-    mock_session.exec.assert_called_once()  # Verify query execution
-    # Optionally, check the statement passed to exec if needed, but can be complex
+    assert len(completed_records) == 2
+    assert {rec.id for rec in completed_records} == {rec1.id, rec3.id}
+    assert len(pending_records) == 1
+    assert pending_records[0].id == rec2.id
+    assert len(failed_records) == 0
 
 
-def test_get_records_by_status_not_found(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    # Mock session.exec(...).all() to return an empty list
-    mock_result = MagicMock()
-    mock_result.all.return_value = []
-    mock_session.exec.return_value = mock_result
+# --- Tests for JSON Metadata Methods ---
 
-    found_records = repo.get_records_by_status(FileStatus.COMPLETED)
+def test_find_by_metadata_found(session: Session, repo: DocumentRepository):
+    """Test finding records using metadata filters."""
+    meta1 = {"author": "Alice", "year": 2023, "topic": "db"}
+    meta2 = {"author": "Bob", "year": 2024, "topic": "db"}
+    meta3 = {"author": "Alice", "year": 2024, "topic": "ai"}
 
-    assert found_records == []
-    mock_session.exec.assert_called_once()
+    rec1 = create_test_record(source_path="/meta/1.txt", meta_data=meta1)
+    rec2 = create_test_record(source_path="/meta/2.txt", meta_data=meta2)
+    rec3 = create_test_record(source_path="/meta/3.txt", meta_data=meta3)
+    session.add_all([rec1, rec2, rec3])
+    session.commit()
 
+    # Test single filter
+    results_author_alice = repo.find_by_metadata({"author": "Alice"})
+    assert len(results_author_alice) == 2
+    assert {rec.id for rec in results_author_alice} == {rec1.id, rec3.id}
 
-def test_get_records_by_status_failure(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    mock_session.exec.side_effect = Exception("DB Query Error")
-    with pytest.raises(Exception, match="DB Query Error"):
-        repo.get_records_by_status(FileStatus.FAILED_OCR)
-    mock_session.exec.assert_called_once()
+    # Test multiple filters (AND)
+    results_alice_2024 = repo.find_by_metadata({"author": "Alice", "year": 2024})
+    assert len(results_alice_2024) == 1
+    assert results_alice_2024[0].id == rec3.id
 
+    # Test filter matching numeric value (stored as string in comparison)
+    results_year_2023 = repo.find_by_metadata({"year": 2023})
+    assert len(results_year_2023) == 1
+    assert results_year_2023[0].id == rec1.id
 
-# --- Tests for get_records_needing_ocr ---
+    # Test filter resulting in no matches
+    results_no_match = repo.find_by_metadata({"topic": "cloud", "author": "Alice"})
+    assert len(results_no_match) == 0
 
+    # Test empty filter (should return all records with meta_data, technically)
+    # Current implementation returns all records if filters dict is empty
+    results_empty_filter = repo.find_by_metadata({})
+    assert len(results_empty_filter) == 3
+    assert {rec.id for rec in results_empty_filter} == {rec1.id, rec2.id, rec3.id}
 
-def test_get_records_needing_ocr_found(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    records = [
-        FileRecord(id=uuid.uuid4(), source_path="/no_text1.txt", extracted_text=None),
-        FileRecord(id=uuid.uuid4(), source_path="/no_text2.pdf", extracted_text=None),
-    ]
-    mock_result = MagicMock()
-    mock_result.all.return_value = records
-    mock_session.exec.return_value = mock_result
+def test_find_by_metadata_not_found(repo: DocumentRepository):
+    """Test finding records by metadata when no records have metadata."""
+    results = repo.find_by_metadata({"author": "Nobody"})
+    assert len(results) == 0
 
-    found_records = repo.get_records_needing_ocr()
-
-    assert found_records == records
-    mock_session.exec.assert_called_once()
-    # Could add more specific checks on the select statement if needed
-
-
-def test_get_records_needing_ocr_not_found(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    mock_result = MagicMock()
-    mock_result.all.return_value = []
-    mock_session.exec.return_value = mock_result
-
-    found_records = repo.get_records_needing_ocr()
-
-    assert found_records == []
-    mock_session.exec.assert_called_once()
-
-
-def test_get_records_needing_ocr_failure(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    mock_session.exec.side_effect = Exception("DB Query Error for OCR")
-    with pytest.raises(Exception, match="DB Query Error for OCR"):
-        repo.get_records_needing_ocr()
-    mock_session.exec.assert_called_once()
-
-
-# --- Tests for get_records_needing_metadata ---
-
-
-def test_get_records_needing_metadata_found(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    records = [
-        FileRecord(
-            id=uuid.uuid4(),
-            source_path="/needs_meta1.txt",
-            extracted_text="text",
-            meta_data=None,
-        ),
-        FileRecord(
-            id=uuid.uuid4(),
-            source_path="/needs_meta2.pdf",
-            extracted_text="more text",
-            meta_data=None,
-        ),
-    ]
-    mock_result = MagicMock()
-    mock_result.all.return_value = records
-    mock_session.exec.return_value = mock_result
-
-    found_records = repo.get_records_needing_metadata()
-
-    assert found_records == records
-    mock_session.exec.assert_called_once()
-
-
-def test_get_records_needing_metadata_not_found(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    mock_result = MagicMock()
-    mock_result.all.return_value = []
-    mock_session.exec.return_value = mock_result
-
-    found_records = repo.get_records_needing_metadata()
-
-    assert found_records == []
-    mock_session.exec.assert_called_once()
-
-
-def test_get_records_needing_metadata_failure(mock_session: MagicMock):
-    repo = FileRepository(mock_session)
-    mock_session.exec.side_effect = Exception("DB Query Error for Metadata")
-    with pytest.raises(Exception, match="DB Query Error for Metadata"):
-        repo.get_records_needing_metadata()
-    mock_session.exec.assert_called_once()
+# TODO: Add tests for get_records_needing_ocr, get_records_needing_metadata
+# TODO: Add tests for find_by_metadata (more edge cases?), get_distinct_values, get_queryable_fields once implemented

--- a/tests/core/db/test_repositories.py
+++ b/tests/core/db/test_repositories.py
@@ -11,7 +11,6 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine
 
 # Modules/Classes to test
-from reg_agent.core.db import models
 from reg_agent.core.db.models import FileRecord, FileStatus
 from reg_agent.core.db.repositories import DocumentRepository
 
@@ -41,7 +40,7 @@ def create_test_record(
     status: FileStatus = FileStatus.PENDING_PROCESS,
     extracted_text: str | None = None,
     meta_data: dict | None = None,
-    record_id: uuid.UUID | None = None, # Allow specifying ID for testing get_by_id
+    record_id: uuid.UUID | None = None,  # Allow specifying ID for testing get_by_id
 ) -> FileRecord:
     """Helper function to create a FileRecord with defaults."""
     return FileRecord(
@@ -74,7 +73,7 @@ def test_get_by_id_exists(session: Session, repo: DocumentRepository):
     """Test retrieving an existing record by ID."""
     record_id = uuid.uuid4()
     record = create_test_record(record_id=record_id, source_path="/get/exists.txt")
-    session.add(record) # Add directly to session for setup
+    session.add(record)  # Add directly to session for setup
     session.commit()
 
     retrieved_record = repo.get_by_id(record_id)
@@ -110,7 +109,9 @@ def test_exists_by_source_path_false(repo: DocumentRepository):
 def test_get_records_by_status(session: Session, repo: DocumentRepository):
     """Test retrieving records based on their status."""
     rec1 = create_test_record(source_path="/status/1.txt", status=FileStatus.COMPLETED)
-    rec2 = create_test_record(source_path="/status/2.txt", status=FileStatus.PENDING_PROCESS)
+    rec2 = create_test_record(
+        source_path="/status/2.txt", status=FileStatus.PENDING_PROCESS
+    )
     rec3 = create_test_record(source_path="/status/3.txt", status=FileStatus.COMPLETED)
     session.add_all([rec1, rec2, rec3])
     session.commit()
@@ -127,6 +128,7 @@ def test_get_records_by_status(session: Session, repo: DocumentRepository):
 
 
 # --- Tests for JSON Metadata Methods ---
+
 
 def test_find_by_metadata_found(session: Session, repo: DocumentRepository):
     """Test finding records using metadata filters."""
@@ -165,18 +167,20 @@ def test_find_by_metadata_found(session: Session, repo: DocumentRepository):
     assert len(results_empty_filter) == 3
     assert {rec.id for rec in results_empty_filter} == {rec1.id, rec2.id, rec3.id}
 
+
 def test_find_by_metadata_not_found(repo: DocumentRepository):
     """Test finding records by metadata when no records have metadata."""
     results = repo.find_by_metadata({"author": "Nobody"})
     assert len(results) == 0
+
 
 def test_get_distinct_values(session: Session, repo: DocumentRepository):
     """Test getting distinct values for a metadata key."""
     meta1 = {"author": "Alice", "year": 2023, "topic": "db"}
     meta2 = {"author": "Bob", "year": 2024, "topic": "db"}
     meta3 = {"author": "Alice", "year": 2024, "topic": "ai"}
-    meta4 = {"author": "Charlie", "year": 2023} # Missing topic
-    meta5 = {"author": "Alice", "year": 2023, "topic": "db"} # Duplicate author/topic
+    meta4 = {"author": "Charlie", "year": 2023}  # Missing topic
+    meta5 = {"author": "Alice", "year": 2023, "topic": "db"}  # Duplicate author/topic
 
     rec1 = create_test_record(source_path="/meta/1.txt", meta_data=meta1)
     rec2 = create_test_record(source_path="/meta/2.txt", meta_data=meta2)
@@ -204,10 +208,12 @@ def test_get_distinct_values(session: Session, repo: DocumentRepository):
     distinct_nonexistent = repo.get_distinct_values("nonexistent_key")
     assert len(distinct_nonexistent) == 0
 
+
 def test_get_distinct_values_no_metadata(repo: DocumentRepository):
     """Test getting distinct values when no records have metadata."""
     distinct_authors = repo.get_distinct_values("author")
     assert len(distinct_authors) == 0
+
 
 # TODO: Add tests for get_records_needing_ocr, get_records_needing_metadata
 # TODO: Add tests for find_by_metadata (more edge cases?), get_queryable_fields once implemented

--- a/tests/core/db/test_repositories.py
+++ b/tests/core/db/test_repositories.py
@@ -170,5 +170,44 @@ def test_find_by_metadata_not_found(repo: DocumentRepository):
     results = repo.find_by_metadata({"author": "Nobody"})
     assert len(results) == 0
 
+def test_get_distinct_values(session: Session, repo: DocumentRepository):
+    """Test getting distinct values for a metadata key."""
+    meta1 = {"author": "Alice", "year": 2023, "topic": "db"}
+    meta2 = {"author": "Bob", "year": 2024, "topic": "db"}
+    meta3 = {"author": "Alice", "year": 2024, "topic": "ai"}
+    meta4 = {"author": "Charlie", "year": 2023} # Missing topic
+    meta5 = {"author": "Alice", "year": 2023, "topic": "db"} # Duplicate author/topic
+
+    rec1 = create_test_record(source_path="/meta/1.txt", meta_data=meta1)
+    rec2 = create_test_record(source_path="/meta/2.txt", meta_data=meta2)
+    rec3 = create_test_record(source_path="/meta/3.txt", meta_data=meta3)
+    rec4 = create_test_record(source_path="/meta/4.txt", meta_data=meta4)
+    rec5 = create_test_record(source_path="/meta/5.txt", meta_data=meta5)
+    rec_no_meta = create_test_record(source_path="/meta/none.txt", meta_data=None)
+
+    session.add_all([rec1, rec2, rec3, rec4, rec5, rec_no_meta])
+    session.commit()
+
+    # Test distinct authors
+    distinct_authors = repo.get_distinct_values("author")
+    assert sorted(distinct_authors) == ["Alice", "Bob", "Charlie"]
+
+    # Test distinct topics (should ignore null/missing)
+    distinct_topics = repo.get_distinct_values("topic")
+    assert sorted(distinct_topics) == ["ai", "db"]
+
+    # Test distinct years (values stored as numbers, compared as strings by impl.)
+    distinct_years = repo.get_distinct_values("year")
+    assert sorted(distinct_years) == ["2023", "2024"]
+
+    # Test key that doesn't exist
+    distinct_nonexistent = repo.get_distinct_values("nonexistent_key")
+    assert len(distinct_nonexistent) == 0
+
+def test_get_distinct_values_no_metadata(repo: DocumentRepository):
+    """Test getting distinct values when no records have metadata."""
+    distinct_authors = repo.get_distinct_values("author")
+    assert len(distinct_authors) == 0
+
 # TODO: Add tests for get_records_needing_ocr, get_records_needing_metadata
-# TODO: Add tests for find_by_metadata (more edge cases?), get_distinct_values, get_queryable_fields once implemented
+# TODO: Add tests for find_by_metadata (more edge cases?), get_queryable_fields once implemented

--- a/tests/core/db/test_unit_of_work.py
+++ b/tests/core/db/test_unit_of_work.py
@@ -1,0 +1,107 @@
+# tests/core/db/test_unit_of_work.py
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the class to test
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
+from reg_agent.core.db.repositories import DocumentRepository
+
+
+@pytest.fixture
+def mock_session_context():
+    """Mocks the context manager returned by get_session."""
+    mock_cm = MagicMock()
+    # Mock the session object returned when entering the context
+    mock_session = MagicMock(name="MockSession")
+    mock_cm.__enter__.return_value = mock_session
+    mock_cm.__exit__.return_value = None  # Simulate successful exit by default
+    return mock_cm, mock_session
+
+
+@patch("reg_agent.core.db.unit_of_work.get_session")
+def test_uow_enter_exit_success(mock_get_session, mock_session_context):
+    """Test successful entry, commit, and exit."""
+    mock_cm, mock_session = mock_session_context
+    mock_get_session.return_value = mock_cm
+
+    with SqlModelUnitOfWork() as uow:
+        # Check repository is initialized
+        assert isinstance(uow.documents, DocumentRepository)
+        assert uow.documents.session == mock_session
+        # Simulate doing some work
+        pass
+
+    # Assertions on exit
+    mock_get_session.assert_called_once()
+    mock_cm.__enter__.assert_called_once()
+    mock_session.commit.assert_called_once()
+    mock_session.rollback.assert_not_called()
+    mock_cm.__exit__.assert_called_once()  # UoW.close calls this
+
+
+@patch("reg_agent.core.db.unit_of_work.get_session")
+def test_uow_exit_with_exception(mock_get_session, mock_session_context):
+    """Test rollback and exit when an exception occurs."""
+    mock_cm, mock_session = mock_session_context
+    mock_get_session.return_value = mock_cm
+
+    with pytest.raises(ValueError, match="Test Exception"):
+        with SqlModelUnitOfWork() as uow:
+            # Check repository is initialized
+            assert isinstance(uow.documents, DocumentRepository)
+            # Simulate an error during work
+            raise ValueError("Test Exception")
+
+    # Assertions on exit
+    mock_get_session.assert_called_once()
+    mock_cm.__enter__.assert_called_once()
+    mock_session.commit.assert_not_called()  # Commit should not be called
+    mock_session.rollback.assert_called_once()  # Rollback should be called
+    mock_cm.__exit__.assert_called_once()  # UoW.close calls this
+
+
+@patch("reg_agent.core.db.unit_of_work.get_session")
+def test_uow_commit_failure_rolls_back(mock_get_session, mock_session_context):
+    """Test that rollback occurs if commit fails."""
+    mock_cm, mock_session = mock_session_context
+    mock_get_session.return_value = mock_cm
+    # Simulate commit failing
+    commit_error = Exception("Commit Failed")
+    mock_session.commit.side_effect = commit_error
+
+    with pytest.raises(Exception, match="Commit Failed"):
+        with SqlModelUnitOfWork() as _:
+            pass  # Exit normally to trigger commit
+
+    # Assertions on exit
+    mock_get_session.assert_called_once()
+    mock_cm.__enter__.assert_called_once()
+    mock_session.commit.assert_called_once()  # Commit was attempted
+    mock_session.rollback.assert_called_once()  # Rollback should be called
+    mock_cm.__exit__.assert_called_once()
+
+
+@patch("reg_agent.core.db.unit_of_work.get_session")
+def test_uow_rollback_failure_logged(mock_get_session, mock_session_context, caplog):
+    """Test that rollback failure is logged but doesn't prevent closing."""
+    mock_cm, mock_session = mock_session_context
+    mock_get_session.return_value = mock_cm
+    # Simulate rollback failing (e.g., during exception handling)
+    rollback_error = Exception("Rollback Failed")
+    mock_session.rollback.side_effect = rollback_error
+
+    with pytest.raises(ValueError, match="Test Exception"):
+        with SqlModelUnitOfWork() as _:
+            raise ValueError("Test Exception")  # Trigger rollback path
+
+    # Assertions on exit
+    mock_get_session.assert_called_once()
+    mock_cm.__enter__.assert_called_once()
+    mock_session.commit.assert_not_called()
+    mock_session.rollback.assert_called_once()  # Rollback was attempted
+    mock_cm.__exit__.assert_called_once()
+
+    # Check logs for rollback error
+    assert "Exception during UoW rollback." in caplog.text
+    assert "Rollback Failed" in caplog.text

--- a/tests/integration/test_db_integration.py
+++ b/tests/integration/test_db_integration.py
@@ -12,7 +12,6 @@ from sqlalchemy.engine import Engine
 # Import components to test integration
 from reg_agent.core.db.connection import create_db_and_tables, get_engine
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import DocumentRepository
 from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
 
 # Mark all tests in this file as integration tests
@@ -126,7 +125,9 @@ def test_add_and_retrieve_file_record(db_engine: Engine):
                     f"Timestamp mismatch: Retrieved (UTC): {retrieved_ts_aware_rounded}, Original: {timestamp_rounded}"
                 )
             else:
-                pytest.fail("last_modified_ts was None after retrieval, but should not be.")
+                pytest.fail(
+                    "last_modified_ts was None after retrieval, but should not be."
+                )
 
             # --- created_at / updated_at ---
             created_at = retrieved_record.created_at
@@ -146,8 +147,10 @@ def test_add_and_retrieve_file_record(db_engine: Engine):
 
             # Allow a small difference between creation and update time
             assert abs(updated_at_aware - created_at_aware) < datetime.timedelta(
-                seconds=5 # Increased tolerance slightly
-            ), f"created_at ({created_at_aware}) and updated_at ({updated_at_aware}) are too far apart"
+                seconds=5  # Increased tolerance slightly
+            ), (
+                f"created_at ({created_at_aware}) and updated_at ({updated_at_aware}) are too far apart"
+            )
 
     except Exception as e:
         pytest.fail(f"Retrieving record or asserting failed with exception: {e}")
@@ -195,7 +198,9 @@ def test_exists_by_source_path_integration(db_engine: Engine):
     # --- Check non-existent path ---
     try:
         with SqlModelUnitOfWork() as uow:
-            exists_non_existent = uow.documents.exists_by_source_path("/non/existent/path.txt")
+            exists_non_existent = uow.documents.exists_by_source_path(
+                "/non/existent/path.txt"
+            )
     except Exception as e:
         pytest.fail(f"Checking non-existent path failed with exception: {e}")
     assert exists_non_existent is False, "Non-existent path should return False."
@@ -304,6 +309,7 @@ def test_get_records_by_status_integration(db_engine: Engine):
     # assert len(retrieved_pending) == 1
     # assert len(retrieved_completed) == 1
     # assert len(retrieved_failed) == 1
+
 
 # Add tests for find_by_metadata and get_distinct_values if not covered elsewhere
 # (Assuming they have unit tests, integration might be less critical unless complex JSON involved)

--- a/tests/integration/test_db_integration.py
+++ b/tests/integration/test_db_integration.py
@@ -107,24 +107,26 @@ def test_add_and_retrieve_file_record(db_engine: Engine):
             # --- Timestamp Handling --- #
             # --- last_modified_ts ---
             retrieved_ts = retrieved_record.last_modified_ts
-            assert retrieved_ts is not None, "last_modified_ts is None after retrieval" # Mypy hint
+            if retrieved_ts:
+                # retrieved_ts_dt = cast(datetime.datetime, retrieved_ts) # Removed cast
 
-            # Convert retrieved timestamp (potentially naive) to aware UTC
-            if retrieved_ts.tzinfo is None:
-                # Assume the naive time is local, convert to aware UTC
-                # This is less ideal, ideally DB returns TZ aware or consistent UTC
-                retrieved_ts_aware = retrieved_ts.astimezone(datetime.timezone.utc)
+                # Convert retrieved timestamp (potentially naive) to aware UTC
+                if retrieved_ts.tzinfo is None:
+                    # Assume the naive time is local, convert to aware UTC
+                    retrieved_ts_aware = retrieved_ts.astimezone(datetime.timezone.utc)
+                else:
+                    # Already timezone-aware, ensure it's UTC
+                    retrieved_ts_aware = retrieved_ts.astimezone(datetime.timezone.utc)
+
+                # Compare rounded timestamps
+                timestamp_rounded = timestamp.replace(microsecond=0)
+                retrieved_ts_aware_rounded = retrieved_ts_aware.replace(microsecond=0)
+
+                assert retrieved_ts_aware_rounded == timestamp_rounded, (
+                    f"Timestamp mismatch: Retrieved (UTC): {retrieved_ts_aware_rounded}, Original: {timestamp_rounded}"
+                )
             else:
-                # Already timezone-aware, ensure it's UTC
-                retrieved_ts_aware = retrieved_ts.astimezone(datetime.timezone.utc)
-
-            # Compare rounded timestamps
-            timestamp_rounded = timestamp.replace(microsecond=0)
-            retrieved_ts_aware_rounded = retrieved_ts_aware.replace(microsecond=0)
-
-            assert retrieved_ts_aware_rounded == timestamp_rounded, (
-                f"Timestamp mismatch: Retrieved (UTC): {retrieved_ts_aware_rounded}, Original: {timestamp_rounded}"
-            )
+                pytest.fail("last_modified_ts was None after retrieval, but should not be.")
 
             # --- created_at / updated_at ---
             created_at = retrieved_record.created_at

--- a/tests/integration/test_db_integration.py
+++ b/tests/integration/test_db_integration.py
@@ -10,9 +10,10 @@ import pytest
 from sqlalchemy.engine import Engine
 
 # Import components to test integration
-from reg_agent.core.db.connection import create_db_and_tables, get_engine, get_session
+from reg_agent.core.db.connection import create_db_and_tables, get_engine
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import FileRepository
+from reg_agent.core.db.repositories import DocumentRepository
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
 
 # Mark all tests in this file as integration tests
 pytestmark = pytest.mark.integration
@@ -60,7 +61,7 @@ def db_engine(tmp_path: Path) -> Generator[Engine, None, None]:
 
 
 def test_add_and_retrieve_file_record(db_engine: Engine):
-    """Tests adding a record via repository and retrieving it."""
+    """Tests adding a record via repository and retrieving it using UoW."""
     record_id = uuid.uuid4()
     source_path = f"/integration/test_{record_id}.pdf"
     timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
@@ -76,23 +77,22 @@ def test_add_and_retrieve_file_record(db_engine: Engine):
         status=FileStatus.PENDING_PROCESS,
     )
 
-    # --- Add record using repository ---
+    # --- Add record using UoW ---
     try:
-        with get_session(engine=db_engine) as session:
-            repo = FileRepository(session)
-            repo.add(record_to_add)
-        # Session commits automatically on exit
+        with SqlModelUnitOfWork() as uow:
+            uow.documents.add(record_to_add)
+        # UoW commits automatically on exit
     except Exception as e:
         pytest.fail(f"Adding record failed with exception: {e}")
 
-    # --- Retrieve and verify record in a new session ---
+    # --- Retrieve and verify record using UoW in a new context ---
     retrieved_record: FileRecord | None = None
     try:
-        with get_session(engine=db_engine) as session:
-            # Use session.get for direct retrieval by PK
-            retrieved_record = session.get(FileRecord, record_id)
+        with SqlModelUnitOfWork() as uow:
+            # Use repository get method
+            retrieved_record = uow.documents.get(record_id)
 
-            # Perform assertions *inside* the session context
+            # Perform assertions *inside* the UoW context
             assert retrieved_record is not None, (
                 "Record was not found in the database after add."
             )
@@ -105,20 +105,20 @@ def test_add_and_retrieve_file_record(db_engine: Engine):
             assert retrieved_record.status == FileStatus.PENDING_PROCESS
 
             # --- Timestamp Handling --- #
-            # DuckDB might lose microsecond precision or return naive local time
-            retrieved_naive_ts = retrieved_record.last_modified_ts
-            if retrieved_naive_ts.tzinfo is None:
-                # Assume the naive time is local, convert to aware UTC
-                retrieved_ts_aware = retrieved_naive_ts.astimezone(
-                    datetime.timezone.utc
-                )
-            else:
-                # Already timezone-aware (unexpected for duckdb, but handle it)
-                retrieved_ts_aware = retrieved_naive_ts.astimezone(
-                    datetime.timezone.utc
-                )
+            # --- last_modified_ts ---
+            retrieved_ts = retrieved_record.last_modified_ts
+            assert retrieved_ts is not None, "last_modified_ts is None after retrieval" # Mypy hint
 
-            # Also round original timestamp for comparison
+            # Convert retrieved timestamp (potentially naive) to aware UTC
+            if retrieved_ts.tzinfo is None:
+                # Assume the naive time is local, convert to aware UTC
+                # This is less ideal, ideally DB returns TZ aware or consistent UTC
+                retrieved_ts_aware = retrieved_ts.astimezone(datetime.timezone.utc)
+            else:
+                # Already timezone-aware, ensure it's UTC
+                retrieved_ts_aware = retrieved_ts.astimezone(datetime.timezone.utc)
+
+            # Compare rounded timestamps
             timestamp_rounded = timestamp.replace(microsecond=0)
             retrieved_ts_aware_rounded = retrieved_ts_aware.replace(microsecond=0)
 
@@ -126,34 +126,33 @@ def test_add_and_retrieve_file_record(db_engine: Engine):
                 f"Timestamp mismatch: Retrieved (UTC): {retrieved_ts_aware_rounded}, Original: {timestamp_rounded}"
             )
 
-            # Check created_at/updated_at
-            assert retrieved_record.created_at is not None
-            assert retrieved_record.updated_at is not None
-            # Convert these to UTC as well if they are naive
+            # --- created_at / updated_at ---
+            created_at = retrieved_record.created_at
+            updated_at = retrieved_record.updated_at
+
+            # Convert to aware UTC if necessary
             created_at_aware = (
-                retrieved_record.created_at.astimezone(datetime.timezone.utc)
-                if retrieved_record.created_at.tzinfo is None
-                else retrieved_record.created_at.astimezone(datetime.timezone.utc)
+                created_at.astimezone(datetime.timezone.utc)
+                if created_at.tzinfo is None
+                else created_at.astimezone(datetime.timezone.utc)
             )
             updated_at_aware = (
-                retrieved_record.updated_at.astimezone(datetime.timezone.utc)
-                if retrieved_record.updated_at.tzinfo is None
-                else retrieved_record.updated_at.astimezone(datetime.timezone.utc)
+                updated_at.astimezone(datetime.timezone.utc)
+                if updated_at.tzinfo is None
+                else updated_at.astimezone(datetime.timezone.utc)
             )
 
+            # Allow a small difference between creation and update time
             assert abs(updated_at_aware - created_at_aware) < datetime.timedelta(
-                seconds=5
-            )  # Allow slightly larger diff
+                seconds=5 # Increased tolerance slightly
+            ), f"created_at ({created_at_aware}) and updated_at ({updated_at_aware}) are too far apart"
 
     except Exception as e:
         pytest.fail(f"Retrieving record or asserting failed with exception: {e}")
 
-    # Final check outside session is less useful due to potential detachment
-    # assert retrieved_record is not None
-
 
 def test_exists_by_source_path_integration(db_engine: Engine):
-    """Tests the exists_by_source_path method against a real DB."""
+    """Tests the exists_by_source_path method against a real DB using UoW."""
     record_id = uuid.uuid4()
     source_path = f"/integration/exists_test_{record_id}.pdf"
     timestamp = datetime.datetime.now(datetime.timezone.utc)
@@ -170,35 +169,139 @@ def test_exists_by_source_path_integration(db_engine: Engine):
 
     # --- Check existence before adding ---
     try:
-        with get_session(engine=db_engine) as session:
-            repo = FileRepository(session)
-            exists_before = repo.exists_by_source_path(source_path)
+        with SqlModelUnitOfWork() as uow:
+            exists_before = uow.documents.exists_by_source_path(source_path)
     except Exception as e:
         pytest.fail(f"Checking existence (before add) failed with exception: {e}")
     assert exists_before is False, "Record should not exist before being added."
 
     # --- Add record ---
     try:
-        with get_session(engine=db_engine) as session:
-            repo = FileRepository(session)
-            repo.add(record_to_add)
+        with SqlModelUnitOfWork() as uow:
+            uow.documents.add(record_to_add)
     except Exception as e:
         pytest.fail(f"Adding record failed with exception: {e}")
 
     # --- Check existence after adding ---
     try:
-        with get_session(engine=db_engine) as session:
-            repo = FileRepository(session)
-            exists_after = repo.exists_by_source_path(source_path)
+        with SqlModelUnitOfWork() as uow:
+            exists_after = uow.documents.exists_by_source_path(source_path)
     except Exception as e:
         pytest.fail(f"Checking existence (after add) failed with exception: {e}")
     assert exists_after is True, "Record should exist after being added."
 
     # --- Check non-existent path ---
     try:
-        with get_session(engine=db_engine) as session:
-            repo = FileRepository(session)
-            exists_nonexistent = repo.exists_by_source_path("/non/existent/path.nada")
+        with SqlModelUnitOfWork() as uow:
+            exists_non_existent = uow.documents.exists_by_source_path("/non/existent/path.txt")
     except Exception as e:
         pytest.fail(f"Checking non-existent path failed with exception: {e}")
-    assert exists_nonexistent is False, "Non-existent path should return False."
+    assert exists_non_existent is False, "Non-existent path should return False."
+
+
+def test_get_records_by_status_integration(db_engine: Engine):
+    """Tests retrieving records by status against a real DB using UoW."""
+    # Generate unique IDs for each record
+    record_id_pending = uuid.uuid4()
+    record_id_completed = uuid.uuid4()
+    record_id_failed = uuid.uuid4()
+
+    source_path_base = "/integration/status_test"
+    timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+
+    record_pending = FileRecord(
+        id=record_id_pending,
+        source_path=f"{source_path_base}_pending.pdf",
+        filename=f"status_test_{record_id_pending}.pdf",
+        blob=b"pending content",
+        size_bytes=15,
+        last_modified_ts=timestamp,
+        status=FileStatus.PENDING_PROCESS,
+    )
+
+    record_completed = FileRecord(
+        id=record_id_completed,
+        source_path=f"{source_path_base}_completed.pdf",
+        filename=f"status_test_{record_id_completed}.pdf",
+        blob=b"completed content",
+        size_bytes=17,
+        last_modified_ts=timestamp,
+        status=FileStatus.COMPLETED,
+    )
+
+    record_failed = FileRecord(
+        id=record_id_failed,
+        source_path=f"{source_path_base}_failed.pdf",
+        filename=f"status_test_{record_id_failed}.pdf",
+        blob=b"failed content",
+        size_bytes=14,
+        last_modified_ts=timestamp,
+        status=FileStatus.FAILED_OCR,
+    )
+
+    # Add records with different statuses using UoW
+    try:
+        with SqlModelUnitOfWork() as uow:
+            uow.documents.add(record_pending)
+            uow.documents.add(record_completed)
+            uow.documents.add(record_failed)
+    except Exception as e:
+        pytest.fail(f"Adding records failed with exception: {e}")
+
+    # Retrieve PENDING_PROCESS records using UoW
+    retrieved_pending = []
+    try:
+        with SqlModelUnitOfWork() as uow:
+            retrieved_pending = uow.documents.get_records_by_status(
+                FileStatus.PENDING_PROCESS
+            )
+            # Perform assertions while the session is active
+            assert len(retrieved_pending) == 1
+            # Compare against the stored UUID directly
+            assert retrieved_pending[0].id == record_id_pending
+            # Check other statuses if needed (optional)
+            # retrieved_completed = uow.documents.get_records_by_status(
+            #     FileStatus.COMPLETED
+            # )
+            # assert len(retrieved_completed) == 1
+            # assert retrieved_completed[0].id == record_completed.id
+
+    except Exception as e:
+        pytest.fail(f"Retrieving PENDING_PROCESS records failed: {e}")
+
+    # Retrieve COMPLETED records using UoW
+    retrieved_completed = []
+    try:
+        with SqlModelUnitOfWork() as uow:
+            retrieved_completed = uow.documents.get_records_by_status(
+                FileStatus.COMPLETED
+            )
+            # Perform assertions while the session is active
+            assert len(retrieved_completed) == 1
+            # Compare against the stored UUID directly
+            assert retrieved_completed[0].id == record_id_completed
+    except Exception as e:
+        pytest.fail(f"Retrieving COMPLETED records failed: {e}")
+
+    # Retrieve FAILED_OCR records using UoW
+    retrieved_failed = []
+    try:
+        with SqlModelUnitOfWork() as uow:
+            retrieved_failed = uow.documents.get_records_by_status(
+                FileStatus.FAILED_OCR
+            )
+            # Perform assertions while the session is active
+            assert len(retrieved_failed) == 1
+            # Compare against the stored UUID directly
+            assert retrieved_failed[0].id == record_id_failed
+    except Exception as e:
+        pytest.fail(f"Retrieving FAILED_OCR records failed: {e}")
+
+    # Optional: Verify counts if needed outside the UoW blocks
+    # (Requires careful handling if objects are needed, maybe fetch IDs only)
+    # assert len(retrieved_pending) == 1
+    # assert len(retrieved_completed) == 1
+    # assert len(retrieved_failed) == 1
+
+# Add tests for find_by_metadata and get_distinct_values if not covered elsewhere
+# (Assuming they have unit tests, integration might be less critical unless complex JSON involved)

--- a/tests/pipelines/ingestion/tasks/test_task_1_create_records.py
+++ b/tests/pipelines/ingestion/tasks/test_task_1_create_records.py
@@ -4,26 +4,42 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy.engine import Engine
-from sqlmodel import Session
+# from sqlalchemy.engine import Engine # No longer needed
+# from sqlmodel import Session # No longer needed
 
-from reg_agent.core.db.repositories import FileRepository
+# Keep this for type hinting the mock
+from reg_agent.core.db.repositories import DocumentRepository
+
+# Import the task function
 from reg_agent.pipelines.ingestion.tasks.task_1_create_records import run_task_1
+
+# Import UoW for type hinting the mock
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
 
 # from tests.core.db.test_connection import test_engine # noqa: F401
 
 
 @pytest.fixture
-def mock_session(mocker):
-    """Fixture to mock the get_session context manager and the session object."""
-    mock_sess = mocker.MagicMock(spec=Session)
-    # Mock the context manager
-    mock_context = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_1_create_records.get_session"
+def mock_uow(mocker):
+    """Fixture to mock the SqlModelUnitOfWork context manager and its repository."""
+    # Mock the UoW class within the task module
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_1_create_records.SqlModelUnitOfWork"
     )
-    # Make the context manager return the mocked session
-    mock_context.return_value.__enter__.return_value = mock_sess
-    return mock_sess
+
+    # Create mock instances for the UoW context and the repository
+    mock_uow_instance = MagicMock(spec=SqlModelUnitOfWork)
+    mock_repo_instance = MagicMock(spec=DocumentRepository)
+
+    # Configure the mock UoW instance to return the mock repo
+    # when its 'documents' attribute is accessed
+    mock_uow_instance.documents = mock_repo_instance
+
+    # Configure the mocked UoW class's __enter__ to return the mock UoW instance
+    mock_uow_class.return_value.__enter__.return_value = mock_uow_instance
+
+    # Return the mock instances for use in tests
+    return mock_uow_class, mock_uow_instance, mock_repo_instance
 
 
 @pytest.fixture
@@ -39,62 +55,55 @@ def source_test_dir(tmp_path: Path) -> Path:
     return source_dir
 
 
-def test_run_task_1_creates_new_records(
-    test_engine: Engine, source_test_dir: Path, mock_session: MagicMock, mocker
-):
-    """Test that Task 1 correctly identifies and stages new file records."""
-    # Mock the FileRepository methods used within the task
-    mock_repo_instance = mocker.MagicMock(spec=FileRepository)
-    mock_repo_instance.exists_by_source_path.return_value = (
-        False  # Assume no files exist initially
-    )
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_1_create_records.FileRepository",
-        return_value=mock_repo_instance,
-    )
+def test_run_task_1_creates_new_records(source_test_dir: Path, mock_uow):
+    """Test that Task 1 correctly identifies and stages new file records using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow
 
-    inserted, skipped, errors = run_task_1(test_engine, source_test_dir)
+    # Assume no files exist initially
+    mock_repo_instance.exists_by_source_path.return_value = False
+
+    # Run the task (no engine needed now)
+    inserted, skipped, errors = run_task_1(source_test_dir)
 
     assert inserted == 3
     assert skipped == 0
     assert errors == 0
+    # Check calls on the repository mock obtained via UoW
     assert mock_repo_instance.exists_by_source_path.call_count == 3
-    assert (
-        mock_session.add.call_count == 3
-    )  # Check that add was called for each new file
+    assert mock_repo_instance.add.call_count == 3
+    # Verify the UoW context manager was used
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
+    # Commit/Rollback checks are implicitly handled by UoW tests, focus here is on repo interaction
 
 
-def test_run_task_1_skips_existing_records(
-    test_engine: Engine, source_test_dir: Path, mock_session: MagicMock, mocker
-):
-    """Test that Task 1 skips files if exists_by_source_path returns True."""
-    mock_repo_instance = mocker.MagicMock(spec=FileRepository)
+def test_run_task_1_skips_existing_records(source_test_dir: Path, mock_uow):
+    """Test that Task 1 skips files if exists_by_source_path returns True using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow
+
     # Simulate that all files already exist in the DB
     mock_repo_instance.exists_by_source_path.return_value = True
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_1_create_records.FileRepository",
-        return_value=mock_repo_instance,
-    )
 
-    inserted, skipped, errors = run_task_1(test_engine, source_test_dir)
+    # Run the task
+    inserted, skipped, errors = run_task_1(source_test_dir)
 
     assert inserted == 0
     assert skipped == 3
     assert errors == 0
     assert mock_repo_instance.exists_by_source_path.call_count == 3
-    mock_session.add.assert_not_called()  # No records should be added
+    mock_repo_instance.add.assert_not_called()  # No records should be added
+    # Verify the UoW context manager was used
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
-def test_run_task_1_handles_os_error(
-    test_engine: Engine, source_test_dir: Path, mock_session: MagicMock, mocker
-):
-    """Test Task 1 error handling when file access causes an OSError."""
-    mock_repo_instance = mocker.MagicMock(spec=FileRepository)
+def test_run_task_1_handles_os_error(source_test_dir: Path, mock_uow, mocker):
+    """Test Task 1 error handling when file access causes an OSError using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow
+
     mock_repo_instance.exists_by_source_path.return_value = False
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_1_create_records.FileRepository",
-        return_value=mock_repo_instance,
-    )
 
     # Mock Path.stat to raise OSError for the second file it tries to stat
     original_stat = Path.stat
@@ -110,39 +119,47 @@ def test_run_task_1_handles_os_error(
 
     mocker.patch.object(Path, "stat", mock_stat)
 
-    inserted, skipped, errors = run_task_1(test_engine, source_test_dir)
+    # Run the task
+    inserted, skipped, errors = run_task_1(source_test_dir)
 
     assert inserted == 2  # First and third file should be processed
     assert skipped == 0
     assert errors == 1  # One error occurred
-    assert mock_session.add.call_count == 2
+    assert mock_repo_instance.add.call_count == 2
+    # Verify the UoW context manager was used
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
-def test_run_task_1_handles_general_exception(
-    test_engine: Engine, source_test_dir: Path, mock_session: MagicMock, mocker
-):
-    """Test Task 1 error handling for unexpected exceptions."""
-    mock_repo_instance = mocker.MagicMock(spec=FileRepository)
+def test_run_task_1_handles_general_exception(source_test_dir: Path, mock_uow):
+    """Test Task 1 error handling for unexpected exceptions using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow
 
-    # Let the first file exist, raise exception on second, skip third
+    # Let the first file be processed, raise exception on second's existence check
     def side_effect(path_str):
         if "file1.txt" in path_str:
-            return False
+            return False  # Process file1
         elif "file2.pdf" in path_str:
             raise ValueError("Unexpected value error")  # Simulate unexpected error
         return False  # Process file3
 
     mock_repo_instance.exists_by_source_path.side_effect = side_effect
 
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_1_create_records.FileRepository",
-        return_value=mock_repo_instance,
-    )
+    # Run the task
+    inserted, skipped, errors = run_task_1(source_test_dir)
 
-    inserted, skipped, errors = run_task_1(test_engine, source_test_dir)
-
-    assert inserted == 2  # file1 and file3 processed
+    assert inserted == 2  # Corrected assertion: file1 and file3 processed
     assert skipped == 0
     assert errors == 1  # Error on file2
-    assert mock_repo_instance.exists_by_source_path.call_count == 3
-    assert mock_session.add.call_count == 2
+    # Here, error is on exists_by_source_path for file2, but the check for file3 still runs
+    assert (
+        mock_repo_instance.exists_by_source_path.call_count == 3
+    )  # Corrected assertion: called for all 3 files
+    assert (
+        mock_repo_instance.add.call_count == 2
+    )  # Corrected assertion: file1 and file3 added
+    # Verify the UoW context manager was used
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()

--- a/tests/pipelines/ingestion/tasks/test_task_2_ocr.py
+++ b/tests/pipelines/ingestion/tasks/test_task_2_ocr.py
@@ -4,13 +4,12 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy.engine import Engine
-from sqlmodel import Session
 
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import FileRepository
+from reg_agent.core.db.repositories import DocumentRepository
 from reg_agent.pipelines.ingestion.tasks.task_2_ocr import run_task_2
 from reg_agent.services.ocr_service import OcrService
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
 
 # Use the existing engine fixture from connection tests
 # from tests.core.db.test_connection import test_engine # noqa: F401
@@ -32,180 +31,189 @@ def mock_ocr_service(mocker) -> MagicMock:
 
 
 @pytest.fixture
-def mock_session_task2(mocker):
-    """Fixture to mock the get_session context manager and the session object for Task 2 tests."""
-    mock_sess = mocker.MagicMock(spec=Session)
-    mock_context = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.get_session"
+def mock_uow_task2(mocker):
+    """Fixture to mock the SqlModelUnitOfWork for Task 2 tests."""
+    # Mock the UoW class within the task module
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.SqlModelUnitOfWork"
     )
-    mock_context.return_value.__enter__.return_value = mock_sess
-    return mock_sess
+    mock_uow_instance = MagicMock(spec=SqlModelUnitOfWork)
+    mock_repo_instance = MagicMock(spec=DocumentRepository)
+    mock_uow_instance.documents = mock_repo_instance
+    mock_uow_class.return_value.__enter__.return_value = mock_uow_instance
+    return mock_uow_class, mock_uow_instance, mock_repo_instance
 
 
 @pytest.fixture
 def pending_ocr_records() -> list[FileRecord]:
     """Creates a list of dummy FileRecord objects with PENDING_PROCESS status."""
+    # Return fresh copies each time to avoid state leakage between tests
     return [
         FileRecord(
             id=uuid.uuid4(),
             source_path="/path/file1.pdf",
             status=FileStatus.PENDING_PROCESS,
+            blob=b"pdf_content_1",  # Add dummy blob
+            extracted_text=None,
         ),
         FileRecord(
             id=uuid.uuid4(),
             source_path="/path/file2.pdf",
             status=FileStatus.PENDING_PROCESS,
+            blob=b"pdf_content_2",  # Add dummy blob
+            extracted_text=None,
         ),
     ]
-
-
-@pytest.fixture
-def mock_file_repo_task2(mocker, pending_ocr_records) -> MagicMock:
-    """Mocks the FileRepository specifically for Task 2 tests."""
-    mock_repo = mocker.MagicMock(spec=FileRepository)
-    mock_repo.get_records_by_status.return_value = pending_ocr_records
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.FileRepository",
-        return_value=mock_repo,
-    )
-    return mock_repo
 
 
 # --- Test Functions ---
 
 
 def test_run_task_2_success(
-    test_engine: Engine,
     mock_ocr_service: MagicMock,
-    mock_session_task2: MagicMock,
-    mock_file_repo_task2: MagicMock,
+    mock_uow_task2,
     pending_ocr_records,
 ):
-    """Test Task 2 happy path: finds records, performs OCR, updates status."""
-    found, success, skipped, errors = run_task_2(test_engine)
+    """Test Task 2 happy path: finds records, performs OCR, updates status using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task2
+    # Configure the mock repo provided by the UoW mock
+    mock_repo_instance.get_records_by_status.return_value = pending_ocr_records
+
+    found, success, skipped, errors = run_task_2()  # No engine arg
 
     assert found == 2
     assert success == 2
     assert skipped == 0
     assert errors == 0
-    mock_file_repo_task2.get_records_by_status.assert_called_once_with(
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
         FileStatus.PENDING_PROCESS
     )
     assert mock_ocr_service.extract_markdown_from_file.call_count == 2
-    assert mock_session_task2.add.call_count == 2
     # Check if status was updated correctly on the mock records
     assert pending_ocr_records[0].status == FileStatus.PENDING_METADATA
     assert pending_ocr_records[1].status == FileStatus.PENDING_METADATA
     assert pending_ocr_records[0].extracted_text == "# Mock OCR Text"
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 def test_run_task_2_no_records_found(
-    test_engine: Engine,
     mock_ocr_service: MagicMock,
-    mock_session_task2: MagicMock,
-    mock_file_repo_task2: MagicMock,
+    mock_uow_task2,
 ):
-    """Test Task 2 when no records with PENDING_PROCESS status are found."""
-    mock_file_repo_task2.get_records_by_status.return_value = []  # Simulate no records found
+    """Test Task 2 when no records with PENDING_PROCESS status are found using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task2
+    mock_repo_instance.get_records_by_status.return_value = []  # Simulate no records
 
-    found, success, skipped, errors = run_task_2(test_engine)
+    found, success, skipped, errors = run_task_2()  # No engine arg
 
     assert found == 0
     assert success == 0
     assert skipped == 0
     assert errors == 0
-    mock_file_repo_task2.get_records_by_status.assert_called_once_with(
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
         FileStatus.PENDING_PROCESS
     )
     mock_ocr_service.extract_markdown_from_file.assert_not_called()
-    mock_session_task2.add.assert_not_called()
+    # Verify UoW usage (entered and exited even if no records)
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 def test_run_task_2_ocr_skipped(
-    test_engine: Engine,
     mock_ocr_service: MagicMock,
-    mock_session_task2: MagicMock,
-    mock_file_repo_task2: MagicMock,
+    mock_uow_task2,
     pending_ocr_records,
 ):
-    """Test Task 2 when OCR service returns None (e.g., non-PDF)."""
+    """Test Task 2 when OCR service returns None (e.g., non-PDF) using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task2
+    mock_repo_instance.get_records_by_status.return_value = pending_ocr_records
     mock_ocr_service.extract_markdown_from_file.return_value = None  # Simulate skip
 
-    found, success, skipped, errors = run_task_2(test_engine)
+    found, success, skipped, errors = run_task_2()  # No engine arg
 
     assert found == 2
     assert success == 0
     assert skipped == 2
     assert errors == 0
     assert mock_ocr_service.extract_markdown_from_file.call_count == 2
-    assert mock_session_task2.add.call_count == 2
     assert pending_ocr_records[0].status == FileStatus.SKIPPED_OCR
     assert pending_ocr_records[1].status == FileStatus.SKIPPED_OCR
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 def test_run_task_2_ocr_error(
-    test_engine: Engine,
     mock_ocr_service: MagicMock,
-    mock_session_task2: MagicMock,
-    mock_file_repo_task2: MagicMock,
+    mock_uow_task2,
     pending_ocr_records,
 ):
-    """Test Task 2 when OCR service raises an exception."""
+    """Test Task 2 when OCR service raises an exception using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task2
+    mock_repo_instance.get_records_by_status.return_value = pending_ocr_records
     ocr_exception = Exception("Simulated OCR engine failure")
     mock_ocr_service.extract_markdown_from_file.side_effect = ocr_exception
 
-    found, success, skipped, errors = run_task_2(test_engine)
+    found, success, skipped, errors = run_task_2()  # No engine arg
 
     assert found == 2
     assert success == 0
     assert skipped == 0
     assert errors == 2
     assert mock_ocr_service.extract_markdown_from_file.call_count == 2
-    assert (
-        mock_session_task2.add.call_count == 2
-    )  # Add is called to update status to FAILED
     assert pending_ocr_records[0].status == FileStatus.FAILED_OCR
     assert pending_ocr_records[1].status == FileStatus.FAILED_OCR
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
-def test_run_task_2_ocr_service_init_fails(test_engine: Engine, mocker):
-    """Test Task 2 when OcrService fails to initialize."""
+def test_run_task_2_ocr_service_init_fails(mocker):
+    """Test Task 2 when OcrService fails to initialize (UoW should not be used)."""
     mocker.patch(
         "reg_agent.pipelines.ingestion.tasks.task_2_ocr.OcrService",
         side_effect=RuntimeError("Init failed"),
     )
-    mock_get_session = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.get_session"
+    # Mock UoW to check it's NOT called
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.SqlModelUnitOfWork"
     )
 
-    found, success, skipped, errors = run_task_2(test_engine)
+    found, success, skipped, errors = run_task_2()  # No engine arg
 
     assert found == 0
     assert success == 0
     assert skipped == 0
     assert errors == 1  # Error count should reflect the init failure
-    mock_get_session.assert_not_called()  # Should not attempt DB ops if service fails
+    mock_uow_class.assert_not_called()  # UoW should not be entered if service fails
 
 
-def test_run_task_2_ocr_service_converter_none(test_engine: Engine, mocker):
-    """Test Task 2 when OcrService initializes but converter is None."""
+def test_run_task_2_ocr_service_converter_none(mocker):
+    """Test Task 2 when OcrService initializes but converter is None (UoW not used)."""
     mock_service = mocker.MagicMock(spec=OcrService)
     mock_service.converter = None  # Simulate uninitialized converter
     mocker.patch(
         "reg_agent.pipelines.ingestion.tasks.task_2_ocr.OcrService",
         return_value=mock_service,
     )
-    mock_get_session = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.get_session"
+    # Mock UoW to check it's NOT called
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_2_ocr.SqlModelUnitOfWork"
     )
 
-    found, success, skipped, errors = run_task_2(test_engine)
+    found, success, skipped, errors = run_task_2()  # No engine arg
 
     assert found == 0
     assert success == 0
     assert skipped == 0
-    assert errors == 0  # This case logs a warning and exits gracefully, not an error
-    mock_get_session.assert_not_called()
+    assert errors == 0  # Task skips gracefully, no error
+    mock_uow_class.assert_not_called()  # UoW should not be entered
 
 
 # --- End of Test Functions ---

--- a/tests/pipelines/ingestion/tasks/test_task_3_metadata.py
+++ b/tests/pipelines/ingestion/tasks/test_task_3_metadata.py
@@ -4,15 +4,18 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sqlalchemy.engine import Engine
-from sqlmodel import Session
+# from sqlalchemy.engine import Engine # Removed
+# from sqlmodel import Session # Removed
 
 from reg_agent.core.db.models import FileRecord, FileStatus
-from reg_agent.core.db.repositories import FileRepository
+# Keep this for type hinting the mock repository
+from reg_agent.core.db.repositories import DocumentRepository
 from reg_agent.pipelines.ingestion.tasks.task_3_metadata import (
     MetadataExtractionService,
     run_task_3,
 )
+# Import UoW for type hinting the mock
+from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
 from reg_agent.schemas.metadata import RegulationDocumentMetadata
 
 # --- Fixtures ---
@@ -25,510 +28,305 @@ def mock_metadata_service(mocker) -> MagicMock:
     mock_service_instance = mocker.MagicMock(spec=MetadataExtractionService)
 
     # Mock the async extract_metadata method
-    # Create a dummy metadata model instance to return
     dummy_metadata = RegulationDocumentMetadata(
         document_type="Test Doc",
         issuing_agency="Test Agency",
         subject_institution="Test Bank",
         document_identifier="Test-123",
         summary="Test summary.",
-        key_topics=["Topic A"],  # Optional field
-        action_items=[],  # Optional field
+        key_topics=["Topic A"],
+        action_items=[],
     )
     mock_service_instance.extract_metadata = AsyncMock(return_value=dummy_metadata)
-
-    # Mock the async close method
-    mock_service_instance.close = AsyncMock()
 
     # Patch the constructor to return our mocked instance
     mocker.patch(
         "reg_agent.pipelines.ingestion.tasks.task_3_metadata.MetadataExtractionService",
         return_value=mock_service_instance,
     )
+    # Note: We no longer mock .close() as it's not called in the refactored task
 
-    return mock_service_instance  # Return the instance for assertion checks if needed
+    return mock_service_instance
 
 
-@pytest.fixture
-def mock_session_task3(mocker):
-    """Fixture to mock the get_session context manager and the session object for Task 3 tests."""
-    mock_sess = mocker.MagicMock(spec=Session)
-    # Mock session.get to return a dummy record when called
-    # This requires knowing the ID used in the test
-    mock_record = FileRecord(
-        id=uuid.uuid4(),
-        source_path="/path/file1.pdf",
-        status=FileStatus.PENDING_METADATA,
-        extracted_text="Some text",
-    )
-    mock_sess.get.return_value = mock_record
-
-    mock_context = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.get_session"
-    )
-    mock_context.return_value.__enter__.return_value = mock_sess
-    # Store mock_record on the session mock for tests to access the expected ID
-    mock_sess._mock_record = mock_record
-    return mock_sess
+# Removed mock_session_task3
 
 
 @pytest.fixture
-def pending_metadata_records(mock_session_task3) -> list[FileRecord]:
-    """Creates a list containing the dummy FileRecord from the session mock."""
-    # Use the same record ID that session.get will return
-    record = mock_session_task3._mock_record
-    record.status = FileStatus.PENDING_METADATA  # Ensure correct initial status
-    record.extracted_text = "Sample text for metadata extraction."
-    return [record]
+def mock_uow_task3(mocker):
+    """Fixture to mock the SqlModelUnitOfWork for Task 3 tests."""
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.SqlModelUnitOfWork"
+    )
+    mock_uow_instance = MagicMock(spec=SqlModelUnitOfWork)
+    mock_repo_instance = MagicMock(spec=DocumentRepository)
+    mock_uow_instance.documents = mock_repo_instance
+    mock_uow_class.return_value.__enter__.return_value = mock_uow_instance
+    # Add mocks for commit/rollback if needed for specific failure tests
+    # mock_uow_instance.commit = MagicMock()
+    # mock_uow_instance.rollback = MagicMock()
+    return mock_uow_class, mock_uow_instance, mock_repo_instance
 
 
 @pytest.fixture
-def mock_file_repo_task3(mocker, pending_metadata_records) -> MagicMock:
-    """Mocks the FileRepository specifically for Task 3 tests."""
-    mock_repo = mocker.MagicMock(spec=FileRepository)
-    # Simulate finding the records in the initial fetch
-    mock_repo.get_records_by_status.return_value = pending_metadata_records
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.FileRepository",
-        return_value=mock_repo,
-    )
-    return mock_repo
+def pending_metadata_records() -> list[FileRecord]:
+    """Creates a list of dummy FileRecord objects with PENDING_METADATA status."""
+    # Creates two distinct records for testing different scenarios if needed
+    return [
+        FileRecord(
+            id=uuid.uuid4(),
+            source_path="/path/file1.pdf",
+            status=FileStatus.PENDING_METADATA,
+            extracted_text="Sample text for metadata extraction 1.",
+            blob=b"pdf1",
+            meta_data=None,
+        ),
+         FileRecord(
+            id=uuid.uuid4(),
+            source_path="/path/file2.txt", # Different type for variety
+            status=FileStatus.PENDING_METADATA,
+            extracted_text="Sample text for metadata extraction 2.",
+            blob=b"txt2",
+            meta_data=None,
+        ),
+    ]
+
+# Removed mock_file_repo_task3
 
 
 # --- Test Functions ---
-# Note: Tests need to be async due to run_task_3 being async
 
 
 @pytest.mark.asyncio
 async def test_run_task_3_success(
-    test_engine: Engine,
     mock_metadata_service: MagicMock,
-    mock_session_task3: MagicMock,
-    mock_file_repo_task3: MagicMock,
+    mock_uow_task3,
     pending_metadata_records,
 ):
-    """Test Task 3 happy path: finds records, extracts metadata, updates status."""
+    """Test Task 3 happy path: finds records, extracts metadata, updates status using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3
+    mock_repo_instance.get_records_by_status.return_value = pending_metadata_records
+
     # Patch asyncio.sleep to avoid actual sleeping
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3() # No engine arg
 
-    assert found == 1
-    assert success == 1
+    assert found == 2
+    assert success == 2
     assert errors == 0
-    mock_file_repo_task3.get_records_by_status.assert_called_once_with(
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
         FileStatus.PENDING_METADATA
     )
-    mock_metadata_service.extract_metadata.assert_called_once()
-    mock_metadata_service.close.assert_called_once()  # Ensure service is closed
+    assert mock_metadata_service.extract_metadata.call_count == 2
 
-    # Check that session.get was called to retrieve the record for update
-    update_session = mock_session_task3  # Session mock used for updates
-    record_id_to_find = pending_metadata_records[0].id
-    update_session.get.assert_called_with(FileRecord, record_id_to_find)
+    # Check the status and metadata of the record objects passed to the repo mock
+    record1 = pending_metadata_records[0]
+    record2 = pending_metadata_records[1]
+    assert record1.status == FileStatus.COMPLETED
+    assert record1.meta_data is not None
+    assert record1.meta_data["document_type"] == "Test Doc"
+    assert record2.status == FileStatus.COMPLETED
+    assert record2.meta_data is not None
+    assert record2.meta_data["document_type"] == "Test Doc"
 
-    # Check that session.add was called to stage the update
-    update_session.add.assert_called_once()
-    # Check the status and metadata of the record mock that was supposedly added
-    added_record_arg = update_session.add.call_args[0][0]
-    assert added_record_arg.status == FileStatus.COMPLETED
-    assert added_record_arg.meta_data is not None
-    assert added_record_arg.meta_data["document_type"] == "Test Doc"
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_run_task_3_no_records_found(
-    test_engine: Engine,
     mock_metadata_service: MagicMock,
-    mock_file_repo_task3: MagicMock,
+    mock_uow_task3,
 ):
-    """Test Task 3 when no records with PENDING_METADATA status are found."""
-    mock_file_repo_task3.get_records_by_status.return_value = []  # Simulate no records
+    """Test Task 3 when no records with PENDING_METADATA status are found using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3
+    mock_repo_instance.get_records_by_status.return_value = []  # Simulate no records
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3() # No engine arg
 
     assert found == 0
     assert success == 0
     assert errors == 0
     mock_metadata_service.extract_metadata.assert_not_called()
-    mock_metadata_service.close.assert_not_called()
+    # Verify UoW usage (entered and exited even if no records)
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_run_task_3_no_extracted_text(
-    test_engine: Engine,
-    mock_session_task3: MagicMock,
-    mock_file_repo_task3: MagicMock,
+    mock_metadata_service: MagicMock, # Service still needed for init check
+    mock_uow_task3,
     pending_metadata_records,
 ):
-    """Test Task 3 when a record is found but has no extracted_text."""
-    pending_metadata_records[0].extracted_text = None  # Simulate missing text
+    """Test Task 3 when a record is found but has no extracted_text using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3
+    # Modify one record to have no text
+    pending_metadata_records[0].extracted_text = None
+    mock_repo_instance.get_records_by_status.return_value = pending_metadata_records
+
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3() # No engine arg
 
-    assert found == 1
-    assert success == 0
-    assert errors == 1  # Should count as error
-    # Ensure update to FAILED_UNKNOWN happened
-    update_session = mock_session_task3
-    record_id_to_find = pending_metadata_records[0].id
-    update_session.get.assert_called_with(FileRecord, record_id_to_find)
-    update_session.add.assert_called_once()
-    added_record_arg = update_session.add.call_args[0][0]
-    assert added_record_arg.status == FileStatus.FAILED_UNKNOWN
+    assert found == 2
+    assert success == 1 # Only the second record succeeds
+    assert errors == 1  # First record causes an error
+    # Ensure metadata extraction was only called for the second record
+    mock_metadata_service.extract_metadata.assert_called_once_with(
+        pending_metadata_records[1].extracted_text # Called only with text from record 2
+    )
+
+    # Check final status of records
+    assert pending_metadata_records[0].status == FileStatus.FAILED_UNKNOWN
+    assert pending_metadata_records[1].status == FileStatus.COMPLETED
+
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_run_task_3_metadata_extraction_returns_none(
-    test_engine: Engine,
     mock_metadata_service: MagicMock,
-    mock_session_task3: MagicMock,
-    mock_file_repo_task3: MagicMock,
+    mock_uow_task3,
     pending_metadata_records,
 ):
-    """Test Task 3 when metadata extraction call returns None."""
+    """Test Task 3 when metadata extraction call returns None using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3
+    mock_repo_instance.get_records_by_status.return_value = pending_metadata_records
     mock_metadata_service.extract_metadata.return_value = (
-        None  # Simulate API returning None
+        None  # Simulate API returning None for both calls
     )
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3() # No engine arg
 
-    assert found == 1
+    assert found == 2
     assert success == 0
-    assert errors == 1
-    mock_metadata_service.extract_metadata.assert_called_once()
-    mock_metadata_service.close.assert_called_once()
-    # Check status updated to FAILED_METADATA
-    update_session = mock_session_task3
-    added_record_arg = update_session.add.call_args[0][0]
-    assert added_record_arg.status == FileStatus.FAILED_METADATA
+    assert errors == 2 # Both records fail metadata extraction
+    assert mock_metadata_service.extract_metadata.call_count == 2
+    assert pending_metadata_records[0].status == FileStatus.FAILED_METADATA
+    assert pending_metadata_records[1].status == FileStatus.FAILED_METADATA
+
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_run_task_3_metadata_extraction_exception(
-    test_engine: Engine,
     mock_metadata_service: MagicMock,
-    mock_session_task3: MagicMock,
-    mock_file_repo_task3: MagicMock,
+    mock_uow_task3,
     pending_metadata_records,
 ):
-    """Test Task 3 when metadata extraction call raises an exception."""
-    extraction_exception = ValueError("Simulated API error")
-    mock_metadata_service.extract_metadata.side_effect = extraction_exception
+    """Test Task 3 when metadata extraction call raises an exception using UoW."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3
+    mock_repo_instance.get_records_by_status.return_value = pending_metadata_records
+    api_error = Exception("Simulated API Failure")
+    mock_metadata_service.extract_metadata.side_effect = api_error
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3() # No engine arg
 
-    assert found == 1
+    assert found == 2
     assert success == 0
-    assert errors == 1
-    mock_metadata_service.extract_metadata.assert_called_once()
-    # Close should still be called in finally block
-    mock_metadata_service.close.assert_called_once()
-    # Check status updated to FAILED_METADATA
-    update_session = mock_session_task3
+    assert errors == 2 # Both records fail due to API error
+    assert mock_metadata_service.extract_metadata.call_count == 2
+    assert pending_metadata_records[0].status == FileStatus.FAILED_METADATA
+    assert pending_metadata_records[1].status == FileStatus.FAILED_METADATA
 
-    # --- Check DB interaction within the exception handler --- #
-    # get is called once inside the 'except' block's session
-    assert update_session.get.call_count == 1
-    record_id_to_find = pending_metadata_records[0].id
-    update_session.get.assert_called_with(FileRecord, record_id_to_find)
-
-    # add is called once inside the 'except' block's session (since get found the record)
-    assert update_session.add.call_count == 1
-    failed_record_arg = update_session.add.call_args[0][
-        0
-    ]  # Get arg from the single call
-    assert failed_record_arg.status == FileStatus.FAILED_METADATA
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_run_task_3_initial_fetch_fails(test_engine: Engine, mocker):
-    """Test Task 3 when the initial DB query for records fails."""
-    # Mock the FileRepository constructor to return a repo that fails
-    mock_repo = mocker.MagicMock(spec=FileRepository)
-    mock_repo.get_records_by_status.side_effect = Exception(
-        "Initial DB connection error"
-    )
+async def test_run_task_3_service_init_fails(mocker):
+    """Test Task 3 when MetadataExtractionService fails to initialize."""
+    init_error = RuntimeError("Service init failed")
     mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.FileRepository"
-    ).return_value = mock_repo
-    # Mock get_session just to avoid issues, though it shouldn't be heavily used if repo fails
-    _mock_session_ctx = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.get_session"
+         "reg_agent.pipelines.ingestion.tasks.task_3_metadata.MetadataExtractionService",
+         side_effect=init_error
+    )
+    # Mock UoW to check it's NOT called
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.SqlModelUnitOfWork"
     )
 
-    # Mock the service constructor so it doesn't get called
-    mock_service_constructor = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.MetadataExtractionService"
-    )
-
-    found, success, errors = await run_task_3(test_engine)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        found, success, errors = await run_task_3()
 
     assert found == 0
     assert success == 0
-    assert errors == 0
-    mock_repo.get_records_by_status.assert_called_once_with(FileStatus.PENDING_METADATA)
-    mock_service_constructor.assert_not_called()
+    assert errors == 1 # The service init failure
+    mock_uow_class.assert_not_called() # UoW should not be entered
 
 
 @pytest.mark.asyncio
-async def test_run_task_3_success_commit_fails(
-    test_engine: Engine,
-    mocker,
-    mock_metadata_service: MagicMock,
-    pending_metadata_records,
-):
-    """Test Task 3 success case but DB commit fails during update."""
-    record_id_to_process = pending_metadata_records[0].id
-
-    # Mock FileRepository for initial fetch
-    mock_repo = mocker.MagicMock(spec=FileRepository)
-    mock_repo.get_records_by_status.return_value = pending_metadata_records
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.FileRepository"
-    ).return_value = mock_repo
-
-    # Mock sessions returned by get_session
-    mock_initial_session = MagicMock(spec=Session)
-    _mock_update_session_success = MagicMock(spec=Session)
-    mock_update_session_fail_commit = MagicMock(spec=Session)
-
-    # Configure the session that fails on commit
-    mock_update_session_fail_commit.get.return_value = pending_metadata_records[
-        0
-    ]  # Allow get to succeed
-    # mock_update_session_fail_commit.add.side_effect = commit_exception # Remove side effect on add
-
-    # Control which session is returned by get_session
-    session_call_count = 0
-    commit_exception = Exception("Simulated DB Commit Error")
-
-    def get_session_side_effect(*args, **kwargs):
-        nonlocal session_call_count
-        session_call_count += 1
-        mock_ctx = MagicMock()
-        if session_call_count == 1:
-            # First call is initial fetch
-            mock_ctx.__enter__.return_value = mock_initial_session
-            mock_ctx.__exit__.return_value = None  # Success
-            return mock_ctx
-        elif session_call_count == 2:
-            # Second call is the update attempt after successful API call
-            mock_ctx.__enter__.return_value = mock_update_session_fail_commit
-            # Fail on exit (commit)
-            mock_ctx.__exit__.side_effect = commit_exception
-            return mock_ctx
-        else:
-            raise RuntimeError("Unexpected call to get_session")
-
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.get_session",
-        side_effect=get_session_side_effect,
+async def test_run_task_3_uow_context_fails(mocker, mock_metadata_service):
+    """Test Task 3 when the UoW context manager itself fails on entry."""
+    uow_error = Exception("DB Connection Failed")
+    mock_uow_class = mocker.patch(
+        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.SqlModelUnitOfWork"
     )
+    mock_uow_class.return_value.__enter__.side_effect = uow_error
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3()
 
-    assert found == 1
-    assert success == 0  # Success incremented then decremented
-    assert errors == 1  # Error count incremented due to commit failure
-
-    mock_repo.get_records_by_status.assert_called_once_with(FileStatus.PENDING_METADATA)
-    mock_metadata_service.extract_metadata.assert_called_once()
-    mock_metadata_service.close.assert_called_once()
-
-    # Verify the failing session interaction
-    mock_update_session_fail_commit.get.assert_called_once_with(
-        FileRecord, record_id_to_process
-    )
-    mock_update_session_fail_commit.add.assert_called_once()  # Add was attempted
-
-
-@pytest.mark.asyncio
-async def test_run_task_3_api_error_commit_fails(
-    test_engine: Engine,
-    mocker,
-    mock_metadata_service: MagicMock,
-    pending_metadata_records,
-):
-    """Test Task 3 API error case where subsequent DB commit fails."""
-    record_id_to_process = pending_metadata_records[0].id
-
-    # Mock FileRepository for initial fetch
-    mock_repo = mocker.MagicMock(spec=FileRepository)
-    mock_repo.get_records_by_status.return_value = pending_metadata_records
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.FileRepository"
-    ).return_value = mock_repo
-
-    # Mock the service to raise an error during extraction
-    extraction_exception = ValueError("Simulated API error")
-    mock_metadata_service.extract_metadata.side_effect = extraction_exception
-
-    # Mock sessions returned by get_session
-    mock_initial_session = MagicMock(spec=Session)
-    mock_update_session_fail_commit = MagicMock(spec=Session)
-
-    # Configure the session that fails on commit
-    mock_update_session_fail_commit.get.return_value = pending_metadata_records[
-        0
-    ]  # Allow get to succeed
-    # commit_exception = Exception("Simulated DB Commit Error After API Fail") # Defined below
-    # mock_update_session_fail_commit.add.side_effect = commit_exception # Remove side effect on add
-
-    # Control which session is returned by get_session
-    session_call_count = 0
-    commit_exception = Exception("Simulated DB Commit Error After API Fail")
-
-    def get_session_side_effect(*args, **kwargs):
-        nonlocal session_call_count
-        session_call_count += 1
-        mock_ctx = MagicMock()
-        if session_call_count == 1:  # Initial fetch
-            mock_ctx.__enter__.return_value = mock_initial_session
-            mock_ctx.__exit__.return_value = None  # Success
-            return mock_ctx
-        elif session_call_count == 2:  # Update attempt within API error handler
-            mock_ctx.__enter__.return_value = mock_update_session_fail_commit
-            # Fail on exit (commit)
-            mock_ctx.__exit__.side_effect = commit_exception
-            return mock_ctx
-        else:
-            raise RuntimeError("Unexpected call to get_session")
-
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.get_session",
-        side_effect=get_session_side_effect,
-    )
-
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
-
-    assert found == 1
+    assert found == 0 # Found count is determined inside UoW
     assert success == 0
-    assert errors == 1  # Should only count as one error overall
-
-    mock_repo.get_records_by_status.assert_called_once_with(FileStatus.PENDING_METADATA)
-    mock_metadata_service.extract_metadata.assert_called_once()
-    mock_metadata_service.close.assert_called_once()
-
-    # Verify the failing session interaction within the exception handler
-    mock_update_session_fail_commit.get.assert_called_once_with(
-        FileRecord, record_id_to_process
-    )
-    mock_update_session_fail_commit.add.assert_called_once()  # Add was attempted
+    assert errors == 1 # The UoW entry failure
+    mock_metadata_service.extract_metadata.assert_not_called()
+    mock_uow_class.assert_called_once() # UoW class was called
+    mock_uow_class.return_value.__enter__.assert_called_once() # __enter__ was attempted
+    mock_uow_class.return_value.__exit__.assert_not_called() # __exit__ not called
 
 
 @pytest.mark.asyncio
-async def test_run_task_3_service_close_fails(
-    test_engine: Engine,
-    mock_metadata_service: MagicMock,
-    mock_session_task3: MagicMock,
-    mock_file_repo_task3: MagicMock,
-    pending_metadata_records,
-):
-    """Test Task 3 when the metadata_service.close() call fails."""
-    # Simulate close failing
-    close_exception = RuntimeError("Failed to close service cleanly")
-    mock_metadata_service.close.side_effect = close_exception
-
-    # Patch asyncio.sleep to avoid actual sleeping
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
-
-    # Failure during close should not affect the outcome counts
-    assert found == 1
-    assert success == 1  # Metadata was extracted successfully before close failed
-    assert errors == 0  # Error in finally block doesn't increment error count
-
-    mock_file_repo_task3.get_records_by_status.assert_called_once_with(
-        FileStatus.PENDING_METADATA
-    )
-    mock_metadata_service.extract_metadata.assert_called_once()
-    mock_metadata_service.close.assert_called_once()  # Close was attempted
-
-    # Check that DB update still happened correctly
-    update_session = mock_session_task3
-    record_id_to_find = pending_metadata_records[0].id
-    update_session.get.assert_called_with(FileRecord, record_id_to_find)
-    update_session.add.assert_called_once()
-    added_record_arg = update_session.add.call_args[0][0]
-    assert added_record_arg.status == FileStatus.COMPLETED
-    assert added_record_arg.meta_data is not None
-    assert added_record_arg.meta_data["document_type"] == "Test Doc"
-
-
-@pytest.mark.asyncio
-async def test_run_task_3_no_text_get_fails(
-    test_engine: Engine,
+async def test_run_task_3_uow_commit_fails(
     mocker,
-    mock_file_repo_task3: MagicMock,
-    pending_metadata_records,
+    mock_metadata_service: MagicMock,
+    mock_uow_task3,
+    pending_metadata_records
 ):
-    """Test Task 3 no text case where the DB get fails during update."""
-    record_to_process = pending_metadata_records[0]
-    record_to_process.extracted_text = None  # Simulate missing text
-    record_id_to_process = record_to_process.id
+    """Test Task 3 when the UoW commit fails after processing."""
+    mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3
+    mock_repo_instance.get_records_by_status.return_value = pending_metadata_records
 
-    # Mock FileRepository for initial fetch
-    # Need to use the same repo mock setup as the test below
-    mock_repo = mocker.MagicMock(spec=FileRepository)
-    mock_repo.get_records_by_status.return_value = pending_metadata_records
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.FileRepository"
-    ).return_value = mock_repo
-
-    # Mock sessions returned by get_session
-    mock_initial_session = MagicMock(spec=Session)
-    mock_update_session_get_none = MagicMock(spec=Session)
-    mock_update_session_get_none.get.return_value = (
-        None  # Simulate record not found during update
-    )
-
-    # Control which session is returned by get_session
-    session_call_count = 0
-
-    def get_session_side_effect(*args, **kwargs):
-        nonlocal session_call_count
-        session_call_count += 1
-        if session_call_count == 1:  # Initial fetch
-            mock_ctx = MagicMock()
-            mock_ctx.__enter__.return_value = mock_initial_session
-            mock_ctx.__exit__.return_value = None
-            return mock_ctx
-        elif session_call_count == 2:  # Update attempt within no-text handler
-            mock_ctx = MagicMock()
-            mock_ctx.__enter__.return_value = mock_update_session_get_none
-            mock_ctx.__exit__.return_value = None
-            return mock_ctx
-        else:
-            raise RuntimeError("Unexpected call to get_session")
-
-    mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.get_session",
-        side_effect=get_session_side_effect,
-    )
-
-    # Mock the service constructor so it doesn't get called
-    mock_service_constructor = mocker.patch(
-        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.MetadataExtractionService"
-    )
+    # Simulate commit failure by making __exit__ raise an error
+    commit_error = Exception("Simulated Commit Failure")
+    mock_uow_class.return_value.__exit__.side_effect = commit_error
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3(test_engine)
+        found, success, errors = await run_task_3()
 
-    assert found == 1
-    assert success == 0
-    assert errors == 1  # Error because record couldn't be updated
+    # Counts reflect successful processing *before* commit failure
+    assert found == 2
+    assert success == 2
+    # The error count should include the final UoW commit error
+    assert errors == 1
 
-    mock_repo.get_records_by_status.assert_called_once_with(FileStatus.PENDING_METADATA)
-    mock_service_constructor.assert_not_called()
+    # Check record state *before* commit failed
+    assert pending_metadata_records[0].status == FileStatus.COMPLETED
+    assert pending_metadata_records[1].status == FileStatus.COMPLETED
 
-    # Verify the failing session interaction within the no-text handler
-    mock_update_session_get_none.get.assert_called_once_with(
-        FileRecord, record_id_to_process
-    )
-    mock_update_session_get_none.add.assert_not_called()  # Add should not be called if get fails
+    # Verify UoW usage
+    mock_uow_class.assert_called_once()
+    mock_uow_class.return_value.__enter__.assert_called_once()
+    mock_uow_class.return_value.__exit__.assert_called_once()
+
+
+# Remove obsolete tests:
+# - test_run_task_3_success_commit_fails (replaced by test_run_task_3_uow_commit_fails)
+# - test_run_task_3_api_error_commit_fails (UoW commit failure is tested separately)
+# - test_run_task_3_service_close_fails (service.close not called anymore)
+# - test_run_task_3_no_text_get_fails (nested session.get logic removed)

--- a/tests/pipelines/ingestion/tasks/test_task_3_metadata.py
+++ b/tests/pipelines/ingestion/tasks/test_task_3_metadata.py
@@ -8,12 +8,14 @@ import pytest
 # from sqlmodel import Session # Removed
 
 from reg_agent.core.db.models import FileRecord, FileStatus
+
 # Keep this for type hinting the mock repository
 from reg_agent.core.db.repositories import DocumentRepository
 from reg_agent.pipelines.ingestion.tasks.task_3_metadata import (
     MetadataExtractionService,
     run_task_3,
 )
+
 # Import UoW for type hinting the mock
 from reg_agent.core.db.unit_of_work import SqlModelUnitOfWork
 from reg_agent.schemas.metadata import RegulationDocumentMetadata
@@ -81,15 +83,16 @@ def pending_metadata_records() -> list[FileRecord]:
             blob=b"pdf1",
             meta_data=None,
         ),
-         FileRecord(
+        FileRecord(
             id=uuid.uuid4(),
-            source_path="/path/file2.txt", # Different type for variety
+            source_path="/path/file2.txt",  # Different type for variety
             status=FileStatus.PENDING_METADATA,
             extracted_text="Sample text for metadata extraction 2.",
             blob=b"txt2",
             meta_data=None,
         ),
     ]
+
 
 # Removed mock_file_repo_task3
 
@@ -109,7 +112,7 @@ async def test_run_task_3_success(
 
     # Patch asyncio.sleep to avoid actual sleeping
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3() # No engine arg
+        found, success, errors = await run_task_3()  # No engine arg
 
     assert found == 2
     assert success == 2
@@ -145,7 +148,7 @@ async def test_run_task_3_no_records_found(
     mock_repo_instance.get_records_by_status.return_value = []  # Simulate no records
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3() # No engine arg
+        found, success, errors = await run_task_3()  # No engine arg
 
     assert found == 0
     assert success == 0
@@ -159,7 +162,7 @@ async def test_run_task_3_no_records_found(
 
 @pytest.mark.asyncio
 async def test_run_task_3_no_extracted_text(
-    mock_metadata_service: MagicMock, # Service still needed for init check
+    mock_metadata_service: MagicMock,  # Service still needed for init check
     mock_uow_task3,
     pending_metadata_records,
 ):
@@ -169,16 +172,17 @@ async def test_run_task_3_no_extracted_text(
     pending_metadata_records[0].extracted_text = None
     mock_repo_instance.get_records_by_status.return_value = pending_metadata_records
 
-
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3() # No engine arg
+        found, success, errors = await run_task_3()  # No engine arg
 
     assert found == 2
-    assert success == 1 # Only the second record succeeds
+    assert success == 1  # Only the second record succeeds
     assert errors == 1  # First record causes an error
     # Ensure metadata extraction was only called for the second record
     mock_metadata_service.extract_metadata.assert_called_once_with(
-        pending_metadata_records[1].extracted_text # Called only with text from record 2
+        pending_metadata_records[
+            1
+        ].extracted_text  # Called only with text from record 2
     )
 
     # Check final status of records
@@ -205,11 +209,11 @@ async def test_run_task_3_metadata_extraction_returns_none(
     )
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3() # No engine arg
+        found, success, errors = await run_task_3()  # No engine arg
 
     assert found == 2
     assert success == 0
-    assert errors == 2 # Both records fail metadata extraction
+    assert errors == 2  # Both records fail metadata extraction
     assert mock_metadata_service.extract_metadata.call_count == 2
     assert pending_metadata_records[0].status == FileStatus.FAILED_METADATA
     assert pending_metadata_records[1].status == FileStatus.FAILED_METADATA
@@ -233,11 +237,11 @@ async def test_run_task_3_metadata_extraction_exception(
     mock_metadata_service.extract_metadata.side_effect = api_error
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        found, success, errors = await run_task_3() # No engine arg
+        found, success, errors = await run_task_3()  # No engine arg
 
     assert found == 2
     assert success == 0
-    assert errors == 2 # Both records fail due to API error
+    assert errors == 2  # Both records fail due to API error
     assert mock_metadata_service.extract_metadata.call_count == 2
     assert pending_metadata_records[0].status == FileStatus.FAILED_METADATA
     assert pending_metadata_records[1].status == FileStatus.FAILED_METADATA
@@ -253,8 +257,8 @@ async def test_run_task_3_service_init_fails(mocker):
     """Test Task 3 when MetadataExtractionService fails to initialize."""
     init_error = RuntimeError("Service init failed")
     mocker.patch(
-         "reg_agent.pipelines.ingestion.tasks.task_3_metadata.MetadataExtractionService",
-         side_effect=init_error
+        "reg_agent.pipelines.ingestion.tasks.task_3_metadata.MetadataExtractionService",
+        side_effect=init_error,
     )
     # Mock UoW to check it's NOT called
     mock_uow_class = mocker.patch(
@@ -266,8 +270,8 @@ async def test_run_task_3_service_init_fails(mocker):
 
     assert found == 0
     assert success == 0
-    assert errors == 1 # The service init failure
-    mock_uow_class.assert_not_called() # UoW should not be entered
+    assert errors == 1  # The service init failure
+    mock_uow_class.assert_not_called()  # UoW should not be entered
 
 
 @pytest.mark.asyncio
@@ -282,21 +286,18 @@ async def test_run_task_3_uow_context_fails(mocker, mock_metadata_service):
     with patch("asyncio.sleep", new_callable=AsyncMock):
         found, success, errors = await run_task_3()
 
-    assert found == 0 # Found count is determined inside UoW
+    assert found == 0  # Found count is determined inside UoW
     assert success == 0
-    assert errors == 1 # The UoW entry failure
+    assert errors == 1  # The UoW entry failure
     mock_metadata_service.extract_metadata.assert_not_called()
-    mock_uow_class.assert_called_once() # UoW class was called
-    mock_uow_class.return_value.__enter__.assert_called_once() # __enter__ was attempted
-    mock_uow_class.return_value.__exit__.assert_not_called() # __exit__ not called
+    mock_uow_class.assert_called_once()  # UoW class was called
+    mock_uow_class.return_value.__enter__.assert_called_once()  # __enter__ was attempted
+    mock_uow_class.return_value.__exit__.assert_not_called()  # __exit__ not called
 
 
 @pytest.mark.asyncio
 async def test_run_task_3_uow_commit_fails(
-    mocker,
-    mock_metadata_service: MagicMock,
-    mock_uow_task3,
-    pending_metadata_records
+    mocker, mock_metadata_service: MagicMock, mock_uow_task3, pending_metadata_records
 ):
     """Test Task 3 when the UoW commit fails after processing."""
     mock_uow_class, mock_uow_instance, mock_repo_instance = mock_uow_task3

--- a/tests/pipelines/ingestion/tasks/test_task_3_metadata.py
+++ b/tests/pipelines/ingestion/tasks/test_task_3_metadata.py
@@ -118,7 +118,7 @@ async def test_run_task_3_success(
     assert success == 2
     assert errors == 0
     mock_repo_instance.get_records_by_status.assert_called_once_with(
-        FileStatus.PENDING_METADATA
+        [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
     )
     assert mock_metadata_service.extract_metadata.call_count == 2
 
@@ -159,6 +159,11 @@ async def test_run_task_3_no_records_found(
     mock_uow_class.return_value.__enter__.assert_called_once()
     mock_uow_class.return_value.__exit__.assert_called_once()
 
+    # Check that the repo method was still called with the correct statuses
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
+        [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
+    )
+
 
 @pytest.mark.asyncio
 async def test_run_task_3_no_extracted_text(
@@ -183,6 +188,11 @@ async def test_run_task_3_no_extracted_text(
         pending_metadata_records[
             1
         ].extracted_text  # Called only with text from record 2
+    )
+
+    # Check that the repo method was called with the correct statuses
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
+        [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
     )
 
     # Check final status of records
@@ -223,6 +233,11 @@ async def test_run_task_3_metadata_extraction_returns_none(
     mock_uow_class.return_value.__enter__.assert_called_once()
     mock_uow_class.return_value.__exit__.assert_called_once()
 
+    # Check that the repo method was called with the correct statuses
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
+        [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
+    )
+
 
 @pytest.mark.asyncio
 async def test_run_task_3_metadata_extraction_exception(
@@ -250,6 +265,11 @@ async def test_run_task_3_metadata_extraction_exception(
     mock_uow_class.assert_called_once()
     mock_uow_class.return_value.__enter__.assert_called_once()
     mock_uow_class.return_value.__exit__.assert_called_once()
+
+    # Check that the repo method was called with the correct statuses
+    mock_repo_instance.get_records_by_status.assert_called_once_with(
+        [FileStatus.PENDING_METADATA, FileStatus.FAILED_METADATA]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/pipelines/ingestion/test_run.py
+++ b/tests/pipelines/ingestion/test_run.py
@@ -129,8 +129,8 @@ def test_run_pipeline_success(mock_dependencies):
     mock_create_db.assert_called_once_with(mock_engine)
 
     # Check task calls
-    mock_t1.assert_called_once_with(mock_engine, source_path_instance)
-    mock_t2.assert_called_once_with(mock_engine)
+    mock_t1.assert_called_once_with(source_path_instance)
+    mock_t2.assert_called_once_with()
     mock_asyncio_run.assert_called_once()
 
     # Check logging
@@ -248,7 +248,7 @@ def test_run_pipeline_task1_fails(mock_dependencies):
     run_ingestion_pipeline(source_dir=Path(MOCK_SOURCE_DIR))
 
     source_path_instance.is_dir.assert_called_once()
-    mock_t1.assert_called_once_with(mock_engine, source_path_instance)
+    mock_t1.assert_called_once_with(source_path_instance)
     mock_log.exception.assert_called_once_with(
         "An unexpected error occurred during pipeline execution.",
         error="Cannot read file",
@@ -273,13 +273,13 @@ def test_run_pipeline_task2_fails(mock_dependencies):
     run_ingestion_pipeline(source_dir=Path(MOCK_SOURCE_DIR))
 
     source_path_instance.is_dir.assert_called_once()
-    mock_t1.assert_called_once_with(mock_engine, source_path_instance)
-    mock_t2.assert_called_once_with(mock_engine)
+    mock_t1.assert_called_once_with(source_path_instance)
+    mock_t2.assert_called_once_with()
+    mock_asyncio_run.assert_not_called()
     mock_log.exception.assert_called_once_with(
         "An unexpected error occurred during pipeline execution.",
         error="OCR Engine unavailable",
     )
-    mock_asyncio_run.assert_not_called()
 
 
 def test_run_pipeline_task3_fails(mock_dependencies):
@@ -299,8 +299,8 @@ def test_run_pipeline_task3_fails(mock_dependencies):
     run_ingestion_pipeline(source_dir=Path(MOCK_SOURCE_DIR))
 
     source_path_instance.is_dir.assert_called_once()
-    mock_t1.assert_called_once_with(mock_engine, source_path_instance)
-    mock_t2.assert_called_once_with(mock_engine)
+    mock_t1.assert_called_once_with(source_path_instance)
+    mock_t2.assert_called_once_with()
     mock_asyncio_run.assert_called_once()
     mock_log.exception.assert_called_once_with(
         "An unexpected error occurred during pipeline execution.",


### PR DESCRIPTION
This pull request implements the changes described in issue #12.

Key changes:
- Refactored the data access layer to use the Repository pattern (`AbstractDocumentRepository`, `DocumentRepository`).
- Implemented the Unit of Work pattern (`AbstractUnitOfWork`, `SqlModelUnitOfWork`) for managing database sessions and transactions.
- Added new methods to `DocumentRepository` for metadata querying (`find_by_metadata`, `get_distinct_values`, `get_queryable_fields`).
- Updated the `README.md` to reflect these architectural changes.

Closes #12